### PR TITLE
feat(skills): add bot-review coverage to PR review skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Changes to a skill file in the repo are immediately live — no copy or sync ste
 - [`/write-a-prd`](skills/write-a-prd/SKILL.md) — interactive PRD creation through interview, codebase exploration, and module design
 - [`/prd-to-issues`](skills/prd-to-issues/SKILL.md) — break a PRD into GitHub issues using tracer-bullet vertical slices
 - [`/tdd`](skills/tdd/SKILL.md) — test-driven development with red-green-refactor loop and reference guides
+- [`/review-thorough`](skills/review-thorough/SKILL.md) — wraps built-in `/review` and additionally evaluates bot reviews including resolved threads
 
 ## Improvements to consider
 

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -3,11 +3,14 @@ name: pr-review
 user-invocable: true
 description: >
   AI-assisted GitHub PR review that produces concise, copy-paste-ready draft comments with line
-  references and code suggestions. Use this skill whenever the user shares a GitHub PR URL and wants
-  a code review, second-set-of-eyes analysis, or help understanding a PR before approving. Trigger
-  phrases include: "review this PR", "look at this PR", "give me feedback on this PR", "help me
-  review", "PR review", "check this pull request", "I want to approve but need to understand",
-  "draft review comments", or any message containing a github.com/*/pull/* URL.
+  references and code suggestions. Cross-checks prior bot-generated reviews (Copilot, CodeRabbit,
+  Codex, Sourcery, Gemini Code Assist, etc.) including resolved threads, and surfaces silent
+  dismissals where bot-flagged code was resolved without change. Use this skill whenever the user
+  shares a GitHub PR URL and wants a code review, second-set-of-eyes analysis, or help
+  understanding a PR before approving. Trigger phrases include: "review this PR", "look at this
+  PR", "give me feedback on this PR", "help me review", "PR review", "check this pull request",
+  "review with bots", "check bot feedback", "I want to approve but need to understand", "draft
+  review comments", or any message containing a github.com/*/pull/* URL.
 ---
 
 # PR Review
@@ -155,7 +158,62 @@ State the detected type at the top of your output.
 
 ---
 
-## Step 6: Before you write a comment, verify it
+## Step 6: Cross-check prior bot reviews
+
+Bots frequently leave review comments that get marked resolved without a corresponding code change. "Resolved" on GitHub requires no code change — anyone with write access can click it — so resolution is not evidence a concern was addressed.
+
+Account for: Copilot, Codex, CodeRabbit, Sourcery, Gemini Code Assist, and anything else authored by a GitHub App. Fetch every thread regardless of resolution state:
+
+```bash
+gh api graphql -f query='
+  query($owner:String!, $repo:String!, $number:Int!) {
+    repository(owner:$owner, name:$repo) {
+      pullRequest(number:$number) {
+        reviewThreads(first:100) {
+          nodes {
+            id
+            isResolved
+            isOutdated
+            path
+            line
+            originalLine
+            comments(first:20) {
+              nodes {
+                id
+                url
+                author { login __typename }
+                body
+                createdAt
+                line
+                originalLine
+              }
+            }
+          }
+        }
+      }
+    }
+  }' -f owner=<owner> -f repo=<repo> -F number=<num>
+```
+
+Treat a comment as bot-authored if `author.__typename == "Bot"` or the login matches a known bot (e.g. `copilot-pull-request-reviewer[bot]`, `coderabbitai[bot]`).
+
+For each bot comment (resolved or not):
+
+- Restate the claim in one sentence
+- Verify against the current diff — is the flagged code still present, unchanged?
+- Note `isOutdated`: `true` means GitHub detected the referenced lines changed (suggestive of addressed); `false` + `isResolved=true` + code unchanged is the canonical silent-dismissal signature
+- Categorize: **still valid**, **addressed by later commit**, **false positive**, **style-only (linter-configured → ignore)**
+- Any *still-valid* concern that was resolved without a corresponding code change is a **silent dismissal** — promote it into your own 🔴 Bugs or 🟡 Warnings output with the thread URL as traceability
+
+Preserve thread `id`, comment `id`, and comment `url` for linking findings back to GitHub and for any follow-up mutations (e.g. `resolveReviewThread`).
+
+**Pagination caveat:** the query caps at 100 threads × 20 comments each. On very noisy PRs, paginate via `pageInfo { hasNextPage endCursor }` with `after:` cursors before trusting the coverage is complete.
+
+If no bots have commented on the PR, note `No bot reviews present.` and move on — don't fabricate coverage.
+
+---
+
+## Step 7: Before you write a comment, verify it
 
 This is the most important discipline in the skill. Before flagging a concern:
 
@@ -171,7 +229,7 @@ useful.
 
 ---
 
-## Step 7: Output format
+## Step 8: Output format
 
 ### Review mode (default)
 
@@ -192,6 +250,16 @@ classification issues, rollout edge cases. If none, write "None identified.">
 
 ### 💡 Suggestions
 <Optional improvements. Omit this section entirely if nothing genuine to say.>
+
+### 🤖 Bot review coverage
+
+| Bot | File · Line | Status | Assessment |
+|-----|-------------|--------|-----------|
+| Copilot | [src/foo.ts:42](https://github.com/owner/repo/pull/123#discussion_r111) | Resolved, not outdated | Still valid — code unchanged. **Silent dismissal** — promoted into 🔴 Bugs above. |
+| CodeRabbit | [src/bar.ts:10](https://github.com/owner/repo/pull/123#discussion_r222) | Open | Valid, matches current diff. Rolled into 🟡 Warnings above. |
+| Codex | [src/baz.ts:88](https://github.com/owner/repo/pull/123#discussion_r333) | Resolved, outdated | Addressed by commit abc1234. No action. |
+
+<If no bots have commented: write "No bot reviews present." and omit the table.>
 ```
 
 Each comment inside a section uses this format:
@@ -231,7 +299,7 @@ One or two sentences stating the concern and why it matters.
 
 ---
 
-## Step 8: Offer to post to GitHub
+## Step 9: Offer to post to GitHub
 
 After presenting the review, ask:
 

--- a/skills/review-thorough/SKILL.md
+++ b/skills/review-thorough/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: review-thorough
+user-invocable: true
+description: >
+  Wrapper around the built-in /review command that additionally fetches and evaluates every
+  bot-generated review on the PR — including threads marked resolved. Use when you want the
+  standard /review flow plus assurance that prior bot feedback hasn't been silently dismissed.
+  Trigger phrases: "thorough review", "review with bots", "review-thorough", "review this PR
+  including resolved bot comments".
+---
+
+# Thorough PR Review
+
+Perform the built-in `/review` flow in full, then extend it with explicit bot-review coverage.
+"Resolved" on GitHub requires no code change — anyone with write access can click it — so resolution is not evidence a concern was addressed.
+
+---
+
+## Step 1: Run the built-in review
+
+Invoke the built-in `review` command via the Skill tool (`skill="review"`) — the same mechanism Claude Code uses when a user types `/review`. Let it run in full and capture its complete output (summary, bugs, warnings, suggestions). Do not paraphrase, skip, or abbreviate.
+
+## Step 2: Enumerate all bot review threads — resolved or not
+
+Bots to account for include Copilot, Codex, CodeRabbit, Sourcery, Gemini Code Assist, and anything else authored by a GitHub App. Fetch every thread including its resolution state:
+
+```bash
+gh api graphql -f query='
+  query($owner:String!, $repo:String!, $number:Int!) {
+    repository(owner:$owner, name:$repo) {
+      pullRequest(number:$number) {
+        reviewThreads(first:100) {
+          nodes {
+            id
+            isResolved
+            isOutdated
+            path
+            line
+            originalLine
+            comments(first:20) {
+              nodes {
+                id
+                url
+                author { login __typename }
+                body
+                createdAt
+                line
+                originalLine
+              }
+            }
+          }
+        }
+      }
+    }
+  }' -f owner=<owner> -f repo=<repo> -F number=<num>
+```
+
+Preserve thread `id`, comment `id`, and comment `url` — they're the pointers used for linking findings back to GitHub and for any follow-up mutations (e.g. `resolveReviewThread`). Keep `isOutdated` alongside `isResolved`: GitHub flips `isOutdated=true` automatically when the referenced lines change, which is evidence — unlike resolution — that the underlying code moved.
+
+Treat a comment as bot-authored if `author.__typename == "Bot"` or the login matches a known bot (e.g. `copilot-pull-request-reviewer[bot]`, `coderabbitai[bot]`).
+
+## Step 3: Evaluate each bot comment against the current diff
+
+For each bot comment (resolved or not):
+
+- Restate the claim in one sentence
+- Verify against the current diff — is the flagged code still present, unchanged?
+- Note `isOutdated`: `true` means GitHub detected the referenced lines changed (suggestive of addressed); `false` + `isResolved=true` + code unchanged is the canonical silent-dismissal signature
+- Categorize: **still valid**, **addressed by later commit**, **false positive**, **style-only (linter-configured → ignore)**
+- Any *still-valid* concern that was resolved without a corresponding code change is a **silent dismissal** — surface it explicitly, with the thread URL
+
+## Step 4: Output
+
+Append a new section to the standard `/review` output:
+
+```
+### 🤖 Bot review coverage
+
+| Bot | File · Line | Status | Assessment |
+|-----|-------------|--------|-----------|
+| Copilot | [src/foo.ts:42](https://github.com/owner/repo/pull/123#discussion_r111) | Resolved, not outdated | Still valid — code unchanged. **Silent dismissal** — surfacing. |
+| CodeRabbit | [src/bar.ts:10](https://github.com/owner/repo/pull/123#discussion_r222) | Open | Valid, matches current diff. Rolled into 🟡 Warnings above. |
+| Codex | [src/baz.ts:88](https://github.com/owner/repo/pull/123#discussion_r333) | Resolved, outdated | Addressed by commit abc1234. No action. |
+```
+
+Each file·line cell links to the bot comment URL (from `comments.nodes.url`) so silent-dismissal findings are traceable back to the original thread. Promote silent-dismissal items into the main `🔴 Bugs` or `🟡 Warnings` sections with full file/line context, the thread URL, and a draft comment — same format as the built-in review.
+
+If no bots have commented on the PR, write `No bot reviews present.` and move on. Don't fabricate coverage.
+
+---
+
+## Limitations
+
+The GraphQL query fetches up to 100 threads × 20 comments each. Very noisy PRs may exceed either ceiling — if counts approach those limits, paginate via the `pageInfo { hasNextPage endCursor }` fields and loop with `after:` cursors before trusting the coverage is complete.


### PR DESCRIPTION
## Summary

- New `/review-thorough` skill that wraps the built-in `/review` and adds explicit bot-review coverage, including threads marked resolved
- `/pr-review` gains a new Step 6 to cross-check bot reviews and promote silent dismissals into its Bugs/Warnings output
- Shared mechanics across both: GraphQL query captures thread/comment IDs, URLs, `isOutdated`, `createdAt` for traceability and accurate categorization; pagination caveat documented

Motivation: "Resolved" on GitHub requires no code change, so resolution alone is not evidence a bot concern was addressed. These skills surface that gap.

## Test plan

- [ ] Invoke `/review-thorough` on a real PR with bot reviews; verify the output appends a Bot review coverage table and surfaces any silent dismissals
- [ ] Invoke `/pr-review` on a real PR with bot reviews; verify Step 6 runs and the Review-mode output includes the new subsection
- [ ] Invoke either skill on a PR with no bots; verify `No bot reviews present.` is written, no fabrication
- [ ] Spot-check that thread URLs in the output link back to the right GitHub comment