### PR TITLE
feat(skills): milestone-to-tasks + work-next-task for Ralph loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ skills/        Skill drafts before deploying to ~/.claude/skills/
 
 - [Skill Management](workflows/skill-management.md) — three-tier sync architecture, creation flows, launchd watcher
 
+### Explorations
+
+- [Milestone Ralph vs AIHero Ralph](explorations/milestone-ralph-vs-aihero.md) — capability comparison and roadmap implications for the milestone-driven Ralph skills
+
 ### Skills
 
 Skills in this repo are symlinked into `~/.claude/skills/`, making them globally available across all projects. Claude Code only loads skills from `~/.claude/skills/`, so without the symlink a skill defined here would only be accessible when working in this repo. The symlink bridges the two: edit and commit in the repo, use from anywhere.
@@ -41,6 +45,8 @@ Changes to a skill file in the repo are immediately live — no copy or sync ste
 - [`/grill-me`](skills/grill-me/SKILL.md) — stress-test a plan or design through relentless interrogation
 - [`/write-a-prd`](skills/write-a-prd/SKILL.md) — interactive PRD creation through interview, codebase exploration, and module design
 - [`/prd-to-issues`](skills/prd-to-issues/SKILL.md) — break a PRD into GitHub issues using tracer-bullet vertical slices
+- [`/milestone-to-tasks`](skills/milestone-to-tasks/SKILL.md) — generate a structured `tasks.json` + `progress.md` from a GitHub milestone, ready for a Ralph-style loop
+- [`/work-next-task`](skills/work-next-task/SKILL.md) — one iteration of a Ralph loop over `tasks.json`: pick, work, verify, commit. Ships with `scripts/ralph.sh` reference harness
 - [`/tdd`](skills/tdd/SKILL.md) — test-driven development with red-green-refactor loop and reference guides
 
 ## Improvements to consider

--- a/explorations/milestone-ralph-vs-aihero.md
+++ b/explorations/milestone-ralph-vs-aihero.md
@@ -1,0 +1,91 @@
+# Milestone-driven Ralph skill vs. AIHero Ralph conventions
+
+**Date:** 2026-04-17
+**Context:** Design comparison captured during the grill-me session for `milestone-to-tasks` + `work-next-task` skills. Retained for product roadmapping review.
+
+## Sources
+
+- <https://www.aihero.dev/tips-for-ai-coding-with-ralph-wiggum>
+- <https://ghuntley.com/ralph/>
+- <https://www.aihero.dev/getting-started-with-ralph>
+
+## What AIHero / Huntley Ralph provides
+
+A **pattern plus a script**. Key deliverables:
+
+- Two reference shell harnesses: `ralph-once.sh` (HITL, single invocation) and `afk-ralph.sh` (Docker sandbox, fully autonomous)
+- The one-line canonical loop: `while :; do cat PROMPT.md | claude-code ; done`
+- Bash for-loop variant with iteration cap + `<promise>COMPLETE</promise>` exit signal
+- Conventions: `PRD.md` + `progress.txt` + shell script as the three-file foundation
+- A prompt template embedded directly in the harness script
+- Example task-item shape: `category`, `description`, `steps`, `passes: false` (JSON)
+
+User is responsible for authoring: the PRD, the dependency graph, the priority encoding, the verification conventions, the progress file format, and any GitHub integration they want.
+
+## What our solution provides
+
+Two skills plus a reference harness, driven by an existing GitHub artifact (milestone).
+
+- **`milestone-to-tasks`** (generator): reads a GH milestone, produces `tasks.json` + seeded `progress.md` + a `.gitattributes` entry for `merge=union` on `progress.md`.
+- **`work-next-task`** (worker): one-shot iteration — select, drift-check, claim, work, verify, commit.
+- **`scripts/ralph.sh`**: capital-R Ralph shell harness invoking the worker skill headlessly.
+
+## Capability / deliverable comparison
+
+| Dimension | AIHero Ralph | Our solution |
+|---|---|---|
+| What you bring | A hand-written PRD.md + a shell script | A GitHub milestone (already exists in your workflow) |
+| Out-of-the-box deliverables | Pattern + ~10-line shell harness | Two skills, reference shell harness, generated task artifact, generated progress log scaffold |
+| Task list authoring | You write it yourself, free-form structure | Generator infers structure from milestone issues |
+| Priority assignment | You decide, encoded however you like | Inferred from labels → dependency depth → LLM, with user confirmation |
+| Dependency graph | You encode it manually in PRD prose | Parsed from "Blocked by" refs + GH sub-issue links + LLM fallback, user-confirmed |
+| Verification gates | Free-form prose in PRD | Explicit `steps[]` per task, walked as acceptance gates |
+| GitHub integration | None — git-only | Milestone-aware; drift-checked at pickup; auto-syncs closed issues; opens draft PR per task in autonomous mode |
+| Status tracking | Whatever convention you put in your PRD | Standardized enum (`open` / `in_progress` / `done`), prompt-enforced transitions |
+| Progress log shape | Free-form `progress.txt` | Append-only, reverse-chronological, four structured event templates (pickup / success / failure / drift) |
+| Branch discipline | Commits to whatever branch you're on | One branch per task, `<user>/<type>_T<id>-<slug>` matching user conventions |
+| Concurrency / multi-worker | Single-process by default | Standard mode = single-worker; autonomous mode supports concurrent worktrees via fetch-before-select / push-after-claim |
+| Stop conditions | One token (`COMPLETE`), iteration cap, "off the rails" undefined | Five explicit exit conditions, two tokens (`MILESTONE_COMPLETE`, `HALT`), per-task retry cap in config |
+| Mid-flight edits | Implicit (you can edit PRD.md) | First-class — `done → open` with revised steps is the documented revision mechanism |
+| Run modes | `ralph-once.sh` (HITL) or `afk-ralph.sh` (sandbox) | `/loop /work-next-task` (in-session) or `scripts/ralph.sh` (capital-R Ralph) |
+| Artifact lifecycle | Persists until you delete | Ephemeral by design — worker prompts for cleanup when all tasks done |
+| Sandbox / fully-AFK | Yes, ships with Docker sandbox variant | Deferred to v1.x — shell harness ships; sandbox composition is on the user |
+
+## The framing difference
+
+**AIHero Ralph is "a pattern plus a script."** Bring your own PRD shape, dep graph, verification, progress conventions, and tracker integration. Maximum flexibility, maximum setup.
+
+**Our solution is "a GH-milestone-driven workflow with batteries included."** Point at a milestone you already have; the generator produces a structured artifact with deps + priorities + verification inferred and user-confirmed; Ralph runs against it. Same loop pattern at the core, less DIY at the edges.
+
+## Tradeoffs we accept
+
+- **More opinionated.** Assumes GH milestones (or, eventually, PRDs as sub-issues) as the source. AIHero's "any task list" generality is sacrificed.
+- **More setup surface in v1** (two skills + a harness + symlinks vs. one shell script).
+- **Less "fully unattended" out of the box.** AIHero ships Docker sandbox; we defer it.
+
+## Capability gains
+
+- No manual PRD authoring for GH-shop users
+- Verification + dep + priority inference instead of hand-encoding
+- Drift safety against upstream issue changes
+- Multi-worker support across worktrees
+- Structured progress and task lifecycle that humans and bots can both reason over
+- Composable — the same worker skill works against any future generator (PRD-to-tasks, milestone-to-tasks, etc.)
+
+## Net position
+
+For someone already running GH-milestone-driven work, our solution removes the manual-PRD step Ralph requires and adds GH-native lifecycle handling.
+
+For someone whose work isn't in GH milestones, AIHero's pattern is a better starting point until we ship more generators (PRD-to-tasks, etc.).
+
+## Roadmap implications
+
+Items flagged for v1.x / follow-up based on this comparison:
+
+- **Fully-unattended AFK / sandbox variant.** Docker sandbox wrapper, network scoping, secret mounting, resource limits, wall-clock timeout, cost budget, crash-recovery contract, per-iteration log capture, `AFK` skill integration for notifications.
+- **Related generators.** `prd-to-tasks` (PRD with sub-issues → tasks.json) to broaden applicability beyond milestones.
+- **Running `/loop` directly against a PRD's sub-issue graph** — skipping `tasks.json` entirely because deps/priorities are already encoded on the issues. Still uses `progress.md`. Separate related skill; does not replace the milestone flow.
+- **Soft safety check (v1.1):** warn when another branch has recently modified `tasks.json` to catch accidental concurrent standard-mode runs.
+- **Advisory claim files (later):** `claims/<agent-id>.json` with heartbeat if fetch-before-select / push-after-claim proves insufficient under load.
+- **CI watch inside the autonomous loop** instead of composing with separate conventions.
+- **Three-way merge for `--refresh`** if the v1 conservative-merge approach produces surprises.

--- a/skills/milestone-to-tasks/SKILL.md
+++ b/skills/milestone-to-tasks/SKILL.md
@@ -151,6 +151,8 @@ Ensure `.gitattributes` at repo root contains:
 
 Enables clean auto-merge of concurrent progress appends across worktrees. Add only if missing.
 
+> Note: `merge=union` preserves all entries across concurrent appends but does not guarantee strict line ordering after a merge — git applies the two sides in an unspecified order when both sides insert at the top. Use the ISO timestamp in each entry header as the authoritative sort key when a lookback is order-sensitive (e.g., the retry-cap scan in `/work-next-task`).
+
 ### 8. Report output
 
 ```

--- a/skills/milestone-to-tasks/SKILL.md
+++ b/skills/milestone-to-tasks/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: milestone-to-tasks
+user-invocable: true
+description: >
+  Generate a structured tasks.json + progress.md from a GitHub milestone, ready for
+  a Ralph-style loop. Use when user wants to convert a milestone into an LLM-friendly
+  task list, set up a ralph loop against a milestone, or generate a work queue from
+  GitHub issues.
+---
+
+# Milestone to Tasks
+
+Convert a GitHub milestone into a structured `tasks.json` + seeded `progress.md` under `.claude/milestones/<slug>/`. The artifact is the contract consumed by `/work-next-task` (or any other worker skill that respects the schema).
+
+`tasks.json` is a **living specification of the desired end state** — not a plan. Mid-flight edits (adding tasks, flipping `done → open` with revised steps, re-prioritizing) are first-class operations. The worker re-reads the file every iteration.
+
+## Process
+
+### 1. Resolve the milestone
+
+Accept any of:
+
+- Milestone number (e.g., `42`)
+- Milestone URL (`https://github.com/org/repo/milestone/42`)
+- Milestone title (`"Q2 auth cleanup"`)
+
+Auto-detect the repo via `gh repo view` in the current directory. If not in a git repo, ask the user.
+
+Slug the milestone title for file paths: `.claude/milestones/<slug>/`. If title is empty, use `milestone-<number>`.
+
+### 2. Fetch the issues
+
+```bash
+gh issue list --milestone <ref> --state all \
+  --json number,title,body,labels,state,url,assignees
+```
+
+Include closed issues — their state matters for initial `status` and future drift detection.
+
+### 3. Infer priority and dependencies (hybrid)
+
+Explicit signals first, LLM fallback, user confirms.
+
+**Priority** — try in order:
+
+1. Explicit labels: `P0`, `P1`, `P2`, `priority:*`, etc.
+2. Dependency depth: root blockers get higher priority than leaves.
+3. LLM inference from title/body.
+
+**`blocked_by`** — try in order:
+
+1. Parse explicit `Blocked by #N`, `Depends on #N` from issue bodies.
+2. GitHub sub-issue / issue-link relations via `gh api`.
+3. LLM inference from body content.
+
+**`type`** (conventional commit): infer from labels (`type:feat`, `kind/bug`) or body keywords. Default `feat`.
+
+**`category`** (Anthropic-style domain tag): infer from labels (`area:*`, `component:*`) or content. Default `functional`.
+
+### 4. Quiz the user
+
+Show the proposed structure before writing. Example:
+
+```
+Proposed task graph (7 issues):
+
+  T1  P0  feat  #123  Fix widget null-children crash
+          blocked_by: []
+  T2  P1  feat  #124  Add widget empty state
+          blocked_by: [T1]
+  ...
+
+Priority source:  labels (5), depth-inferred (2)
+Dep source:       explicit refs (4), sub-issues (1), LLM-inferred (2)
+
+Confirm graph, or edit before write?
+```
+
+Iterate until approved. Never silently commit LLM inferences for priority or deps.
+
+### 5. Write `tasks.json`
+
+Path: `.claude/milestones/<slug>/tasks.json`.
+
+Schema:
+
+```json
+{
+  "milestone": {
+    "number": 42,
+    "title": "Q2 auth cleanup",
+    "url": "https://github.com/org/repo/milestone/42"
+  },
+  "generated_at": "2026-04-17T10:00:00Z",
+  "config": {
+    "max_retries_per_task": 3,
+    "require_verification": true
+  },
+  "tasks": [
+    {
+      "id": "T1",
+      "github_issue": 123,
+      "title": "Fix widget null-children crash",
+      "type": "feat",
+      "category": "functional",
+      "description": "Brief summary. Worker fetches canonical body from GH at pickup.",
+      "priority": "P0",
+      "status": "open",
+      "blocked_by": [],
+      "steps": [
+        "Run failing test demonstrating null-children crash",
+        "Confirm fix renders empty widget cleanly",
+        "Verify regression test exists"
+      ]
+    }
+  ]
+}
+```
+
+Field notes:
+
+- `id`: monotonic `T<n>`, stable across `--refresh`.
+- `status`: pre-set to `done` if upstream GH issue is already closed (merged, won't-fix, duplicate).
+- `description`: short summary, not a full duplicate of the issue body. Worker fetches canonical body via `gh issue view` on pickup.
+- `steps`: explicit verification gates. Worker walks every step as an acceptance gate before flipping `status: done`. Vague steps lead to failure loops — be specific.
+- `config.max_retries_per_task`: worker halts with `<promise>HALT</promise>` if a task has been `reverted to open` this many times.
+
+### 6. Seed `progress.md`
+
+Path: `.claude/milestones/<slug>/progress.md`. Append-only, reverse-chronological.
+
+Initial entry:
+
+```markdown
+# Progress log — <milestone title>
+
+## 2026-04-17 10:00 — generated
+- Source: milestone #42 (7 issues)
+- Generator: milestone-to-tasks
+- Priority source: labels (5), depth (2)
+- Dep source: explicit (4), sub-issues (1), LLM (2)
+```
+
+### 7. Configure git for concurrent-safe progress appends
+
+Ensure `.gitattributes` at repo root contains:
+
+```
+.claude/milestones/*/progress.md merge=union
+```
+
+Enables clean auto-merge of concurrent progress appends across worktrees. Add only if missing.
+
+### 8. Report output
+
+```
+Wrote:
+  .claude/milestones/<slug>/tasks.json
+  .claude/milestones/<slug>/progress.md
+  .gitattributes (updated)
+
+Next:
+  /work-next-task                    one iteration
+  scripts/ralph.sh                   full capital-R Ralph loop
+  /loop /work-next-task              in-session loop (less Ralph-pure)
+```
+
+## Refresh mode
+
+`/milestone-to-tasks --refresh` — conservative merge from upstream:
+
+- Pull upstream milestone state.
+- **Add** new issues as new tasks (new `T<n>` ids, fresh `status: open`, deps re-inferred and re-confirmed).
+- **Update** `title`, `description`, `labels` on existing tasks.
+- **Never touch** `status`, `blocked_by`, `priority`, `steps` on existing tasks — these are user-owned mid-flight.
+- **Upstream closed → local `done`:** one-directional sync for issue closure.
+- Append a refresh entry to `progress.md`.
+
+`/milestone-to-tasks --force` — full regenerate:
+
+- Rewrite `tasks.json` from upstream.
+- Preserve `status` only (matched by `github_issue`).
+- Lose hand-edits to priority / blocked_by / steps / description.
+- Use when the upstream milestone has been substantially restructured.
+
+## Related / future work
+
+- **`prd-to-tasks` variant:** generate tasks.json from a PRD issue + its sub-issues, for repos that use PRD-with-subissues instead of milestones.
+- **Running `/loop` directly against a PRD's sub-issue graph:** skip tasks.json entirely because deps/priorities are already encoded on the issues. Still uses `progress.md`. Separate related skill; does not replace this one.
+- **Three-way merge for `--refresh`:** if conservative-merge produces surprises, compute upstream / local / common-ancestor diff with per-change confirmation.
+- **Fully-unattended AFK/sandbox variant** (see `work-next-task` Related).

--- a/skills/milestone-to-tasks/SKILL.md
+++ b/skills/milestone-to-tasks/SKILL.md
@@ -171,7 +171,7 @@ Next:
 
 - Pull upstream milestone state.
 - **Add** new issues as new tasks (new `T<n>` ids, fresh `status: open`, deps re-inferred and re-confirmed).
-- **Update** `title`, `description`, `labels` on existing tasks.
+- **Update** `title`, `description` on existing tasks.
 - **Never touch** `status`, `blocked_by`, `priority`, `steps` on existing tasks — these are user-owned mid-flight.
 - **Upstream closed → local `done`:** one-directional sync for issue closure.
 - Append a refresh entry to `progress.md`.

--- a/skills/milestone-to-tasks/SKILL.md
+++ b/skills/milestone-to-tasks/SKILL.md
@@ -161,10 +161,10 @@ Wrote:
   .claude/milestones/<slug>/progress.md
   .gitattributes (updated)
 
-Next:
-  /work-next-task                    one iteration
-  scripts/ralph.sh                   full capital-R Ralph loop
-  /loop /work-next-task              in-session loop (less Ralph-pure)
+Next (run from repo root):
+  /work-next-task                              one iteration
+  ./skills/work-next-task/scripts/ralph.sh     full capital-R Ralph loop
+  /loop /work-next-task                        in-session loop (less Ralph-pure)
 ```
 
 ## Refresh mode

--- a/skills/work-next-task/SKILL.md
+++ b/skills/work-next-task/SKILL.md
@@ -20,7 +20,7 @@ Composes with:
 
 **Inputs:** `.claude/milestones/<slug>/tasks.json` + `.claude/milestones/<slug>/progress.md`. Must already exist — run `/milestone-to-tasks` first.
 
-**Default mode:** standard (single-worker, local-only). `--autonomous` enables push + draft PR + multi-worker discipline.
+**Default mode:** standard (single-worker, local-only). `--autonomous` enables push + draft PR + multi-worker discipline, and suppresses interactive prompts (taking a documented safe default at each prompt site; see steps 1 and 9).
 
 **Mutation surface in `tasks.json`:** only `status` on a single task per iteration. Nothing else is touched. The user owns `priority`, `blocked_by`, `steps`, `description` — these are the living spec.
 
@@ -30,7 +30,13 @@ Composes with:
 
 ### 1. Find and load context
 
-Locate `.claude/milestones/<slug>/tasks.json`. If multiple `<slug>` directories exist, ask the user (or accept `--slug`).
+Locate `.claude/milestones/<slug>/tasks.json`. Resolution order:
+
+1. `--slug <name>` arg if provided.
+2. The sole `<slug>` directory if exactly one exists.
+3. If multiple exist and no `--slug` given:
+   - **Standard mode:** prompt the user to pick.
+   - **Autonomous mode:** halt (emit `<promise>HALT</promise>` with reason "ambiguous slug; pass `--slug <name>`"). Prompts are suppressed under `--autonomous`.
 
 Read `tasks.json` and the top ~20 entries from `progress.md`.
 
@@ -125,12 +131,14 @@ Include the PR number in the progress entry.
 
 ### 9. Check for completion
 
-If ALL tasks in `tasks.json` now have `status: done`, prompt:
+If ALL tasks in `tasks.json` now have `status: done`:
 
-> All tasks complete. Delete `.claude/milestones/<slug>/`? (y/N)
+**Standard mode:** prompt "All tasks complete. Delete `.claude/milestones/<slug>/`? (y/N)".
 
 - **On confirmation:** delete the directory, commit `chore(tasks): cleanup completed milestone <slug>`, emit `<promise>MILESTONE_COMPLETE</promise>`.
 - **On decline:** emit `<promise>MILESTONE_COMPLETE</promise>` anyway; artifacts remain for inspection.
+
+**Autonomous mode:** no prompt (safe default is to keep artifacts). Emit `<promise>MILESTONE_COMPLETE</promise>` immediately; artifacts remain for post-hoc inspection and manual cleanup.
 
 ### 10. Exit
 

--- a/skills/work-next-task/SKILL.md
+++ b/skills/work-next-task/SKILL.md
@@ -58,7 +58,7 @@ Find tasks where:
 
 Among candidates, pick highest `priority` (P0 > P1 > P2). Tiebreak: lowest `id`.
 
-**Retry-cap check:** before committing to the task, count recent `reverted to open` entries for its id in `progress.md`. If count >= `config.max_retries_per_task`, skip the task and halt:
+**Retry-cap check:** before committing to the task, count `reverted to open` entries for its id across the *entire* `progress.md` (not the top-~20 window loaded in step 1). If count >= `config.max_retries_per_task`, skip the task and halt:
 
 - Append drift/halt entry to progress.md
 - Emit `<promise>HALT</promise>` with reason "T<id> exceeded retry cap, needs human review"
@@ -98,10 +98,10 @@ Read the canonical GH issue body via `gh issue view <github_issue>`. Implement t
 
 Walk every item in the task's `steps[]` as an acceptance gate. If any step fails:
 
-- Do **not** commit code changes.
+- Discard uncommitted code changes first: `git restore --staged . && git restore .` plus `git clean -fd` for new files. Prevents stale edits from contaminating the next iteration. Run this **before** the tasks.json / progress.md edits below; because the prior pickup commit (step 5) already persisted tasks.json and progress.md at the in_progress state, restoring the working tree resets everything to that clean baseline and the fresh edits below apply on top.
 - Revert `status: in_progress → open` in tasks.json.
 - Append failure entry to progress.md (template below).
-- Commit: `chore(tasks): T<id> reverted to open`.
+- Commit: `chore(tasks): T<id> reverted to open` (stage only `tasks.json` and `progress.md`).
 - **Autonomous only:** push the revert commit.
 - Exit silently (no completion token). Normal iteration — loop continues.
 

--- a/skills/work-next-task/SKILL.md
+++ b/skills/work-next-task/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: work-next-task
+user-invocable: true
+description: >
+  Run one iteration of a ralph loop against a tasks.json file — pick the next unblocked
+  highest-priority task, do the work, verify, commit, update status + progress log. Use
+  when user wants to advance a task list, pick up the next task, or step a ralph loop.
+---
+
+# Work Next Task
+
+One iteration of a ralph loop over `.claude/milestones/<slug>/tasks.json`. Pick, work, verify, commit, exit.
+
+Composes with:
+
+- `/loop /work-next-task` — in-session convenience (carries session context, less Ralph-pure)
+- `scripts/ralph.sh` — headless shell harness for capital-R Ralph runs (fresh process per iteration, file-only state)
+
+## Contract
+
+**Inputs:** `.claude/milestones/<slug>/tasks.json` + `.claude/milestones/<slug>/progress.md`. Must already exist — run `/milestone-to-tasks` first.
+
+**Default mode:** standard (single-worker, local-only). `--autonomous` enables push + draft PR + multi-worker discipline.
+
+**Mutation surface in `tasks.json`:** only `status` on a single task per iteration. Nothing else is touched. The user owns `priority`, `blocked_by`, `steps`, `description` — these are the living spec.
+
+**progress.md discipline:** append new entries at the **top** (reverse-chronological). **Never edit or delete existing entries.** The two-commit discipline and `git diff` review catch violations.
+
+## Iteration
+
+### 1. Find and load context
+
+Locate `.claude/milestones/<slug>/tasks.json`. If multiple `<slug>` directories exist, ask the user (or accept `--slug`).
+
+Read `tasks.json` and the top ~20 entries from `progress.md`.
+
+### 2. Fetch (autonomous mode only)
+
+```bash
+git fetch
+git rebase origin/<current-branch>
+```
+
+Ensures peer workers' status flips and claims are visible before selecting. Shrinks the race window.
+
+### 3. Select
+
+Find tasks where:
+
+- `status == "open"`, AND
+- All `blocked_by` ids have `status == "done"`
+
+Among candidates, pick highest `priority` (P0 > P1 > P2). Tiebreak: lowest `id`.
+
+**Retry-cap check:** before committing to the task, count recent `reverted to open` entries for its id in `progress.md`. If count >= `config.max_retries_per_task`, skip the task and halt:
+
+- Append drift/halt entry to progress.md
+- Emit `<promise>HALT</promise>` with reason "T<id> exceeded retry cap, needs human review"
+
+**No candidates:**
+
+- If ALL tasks have `status: done` → prompt for cleanup (step 9), then emit `<promise>MILESTONE_COMPLETE</promise>`.
+- Otherwise → emit `<promise>HALT</promise>` with reason "no unblocked tasks; waiting on in_progress tasks".
+
+### 4. Drift check
+
+```bash
+gh issue view <github_issue> --json title,state,labels
+```
+
+Compare upstream `title`, `state`, `labels` to the tasks.json entry. If `state: closed` upstream or labels have changed materially, halt:
+
+- Append drift entry to progress.md
+- Emit `<promise>HALT</promise>` with reason "drift detected on T<id>"
+
+Body changes are expected (maintainers edit descriptions). Do not treat as drift.
+
+### 5. Claim
+
+- Checkout branch `<user>/<type>_T<id>-<slug>` (create if needed). `<user>` from `gh api user -q .login`. `<type>` from the task entry. `<slug>` kebab-cased from task title.
+- Update `tasks.json`: set `status: in_progress` on the selected task **only**.
+- Append pickup entry to `progress.md` (template below).
+- Commit: `chore(tasks): T<id> open → in_progress`.
+
+**Autonomous only:** push the claim commit immediately so peer workers see it on their next fetch.
+
+### 6. Work
+
+Read the canonical GH issue body via `gh issue view <github_issue>`. Implement the change end-to-end. Use the task's `description` + `steps` as the spec. Everything below that level (approach, file layout, ordering) is yours to decide.
+
+### 7. Verify
+
+Walk every item in the task's `steps[]` as an acceptance gate. If any step fails:
+
+- Do **not** commit code changes.
+- Revert `status: in_progress → open` in tasks.json.
+- Append failure entry to progress.md (template below).
+- Commit: `chore(tasks): T<id> reverted to open`.
+- **Autonomous only:** push the revert commit.
+- Exit silently (no completion token). Normal iteration — loop continues.
+
+If all steps pass, continue.
+
+### 8. Commit (success path)
+
+Two discrete commits per iteration:
+
+1. **Code commit:** `<type>(<scope>): <summary> (refs T<id>, #<github_issue>)`
+2. **Task update commit:** `chore(tasks): T<id> → done`
+   - Flip `status: done` in tasks.json.
+   - Append success entry to progress.md.
+   - Stage tasks.json and progress.md together.
+
+**Autonomous only:** push the branch. Open a draft PR:
+
+```bash
+gh pr create --draft \
+  --title "<type>: <summary>" \
+  --body "Closes #<github_issue>
+
+Part of milestone task T<id>."
+```
+
+Include the PR number in the progress entry.
+
+### 9. Check for completion
+
+If ALL tasks in `tasks.json` now have `status: done`, prompt:
+
+> All tasks complete. Delete `.claude/milestones/<slug>/`? (y/N)
+
+- **On confirmation:** delete the directory, commit `chore(tasks): cleanup completed milestone <slug>`, emit `<promise>MILESTONE_COMPLETE</promise>`.
+- **On decline:** emit `<promise>MILESTONE_COMPLETE</promise>` anyway; artifacts remain for inspection.
+
+### 10. Exit
+
+Normal exit — no completion token. The harness continues to the next iteration.
+
+## Exit / completion tokens
+
+The skill emits one of these tokens in its final output so the shell harness can grep for them:
+
+| Token | Meaning | Harness action |
+|---|---|---|
+| `<promise>MILESTONE_COMPLETE</promise>` | All tasks done | exit 0 |
+| `<promise>HALT</promise>` | Drift, retry cap, or no unblocked tasks | exit 1 (human review) |
+| (silent) | Normal one-task iteration complete | continue loop |
+
+## Exit conditions (five)
+
+1. Completed one task successfully → exit silently, loop continues.
+2. Step verification failed → revert to `open`, exit silently, loop continues.
+3. No unblocked tasks available → emit `HALT`.
+4. All tasks done → prompt cleanup, emit `MILESTONE_COMPLETE`.
+5. Drift detected OR retry cap exceeded → emit `HALT`.
+
+## Progress.md entry templates
+
+Use these templates verbatim (with values substituted). Structure keeps the log scannable.
+
+**Pickup** (`open → in_progress`):
+
+```markdown
+## <iso-timestamp> — T<id>: open → in_progress
+**Task:** <title> (GH #<n>)
+**Drift check:** <none | flagged: details>
+**Plan:** <approach>
+```
+
+**Success** (`in_progress → done`):
+
+```markdown
+## <iso-timestamp> — T<id> → done
+**Completed:** <title> (GH #<n>)
+**Files changed:** <list>
+**Decisions:** <key calls and why>
+**Blockers encountered:** <or "none">
+**PR:** #<n>   <!-- autonomous only -->
+**Next unblocked:** <ids>
+**Notes for next iteration:** <optional>
+```
+
+**Failure** (`in_progress → open`):
+
+```markdown
+## <iso-timestamp> — T<id>: reverted to open
+**What failed:** step <N> — <detail>
+**Context:** <what was tried>
+**Suggested next move:** <optional hint for next agent>
+```
+
+**Drift / halt**:
+
+```markdown
+## <iso-timestamp> — T<id>: drift detected, halted
+**Upstream change:** <what differs>
+**Action required:** <human review direction>
+```
+
+## Modes
+
+| Mode | Workers | Fetch before select | Push claim | Push code + draft PR |
+|---|---|---|---|---|
+| standard (default) | 1 (by contract) | optional hygiene | N/A | no |
+| `--autonomous` | N | required | required | required |
+
+**Standard mode is single-worker by contract.** Two standard-mode workers in separate worktrees against the same `tasks.json` will race and double-claim. For multi-worker runs, use `--autonomous` on all of them. Mixing is not supported.
+
+## Mid-flight spec edits
+
+`tasks.json` is a living spec. Expected user edits **between** iterations:
+
+- Flip a `done` task back to `open` with revised `steps` or `description` when the first pass wasn't right.
+- Add a new task (next monotonic `T<n>`) with `status: open`.
+- Adjust `priority` or `blocked_by` as understanding evolves.
+- Tighten `steps` to make acceptance gates more specific.
+
+The worker re-reads the file at the start of every iteration. No refresh command needed for local edits. For upstream (GitHub milestone) changes, run `/milestone-to-tasks --refresh`.
+
+## Related / future work
+
+- **v1.1 soft safety check:** at iteration start, `git log -5 --format=%s .claude/milestones/<slug>/tasks.json` across branches; warn if another branch has recently modified the file. Catches "forgot another worker was running."
+- **Advisory claim files** (`claims/<agent-id>.json` with heartbeat): if fetch-before-select / push-after-claim proves insufficient under load.
+- **Fully-unattended AFK / sandbox variant:** Docker isolation; network scoping to git remote + GH API only; GH token mounted with minimum scope; CPU / mem / disk quotas; wall-clock timeout in addition to `max_retries_per_task`; cost/token budget; crash-recovery discipline for mid-iteration process death; per-iteration log capture at `.claude/milestones/<slug>/logs/<iso>.log`; `AFK` skill integration for halt / completion notifications; explicit transient-vs-logic failure policy.
+- **CI watch inside the autonomous loop** instead of composing with separate conventions.
+- **Alternative source skill** running directly against a PRD's sub-issue graph, skipping tasks.json.

--- a/skills/work-next-task/SKILL.md
+++ b/skills/work-next-task/SKILL.md
@@ -24,7 +24,7 @@ Composes with:
 
 **Mutation surface in `tasks.json`:** only `status` on a single task per iteration. Nothing else is touched. The user owns `priority`, `blocked_by`, `steps`, `description` — these are the living spec.
 
-**progress.md discipline:** append new entries at the **top** (reverse-chronological). **Never edit or delete existing entries.** The two-commit discipline and `git diff` review catch violations.
+**progress.md discipline:** prepend new entries at the **top** (reverse-chronological). **Never edit or delete existing entries.** The two-commit discipline and `git diff` review catch violations.
 
 ## Iteration
 
@@ -65,10 +65,10 @@ Among candidates, pick highest `priority` (P0 > P1 > P2). Tiebreak: lowest `id`.
 ### 4. Drift check
 
 ```bash
-gh issue view <github_issue> --json title,state,labels
+gh issue view <github_issue> --json title,state
 ```
 
-Compare upstream `title`, `state`, `labels` to the tasks.json entry. If `state: closed` upstream or labels have changed materially, halt:
+Compare upstream `title` and `state` to the tasks.json entry. If `state: closed` upstream, halt:
 
 - Append drift entry to progress.md
 - Emit `<promise>HALT</promise>` with reason "drift detected on T<id>"

--- a/skills/work-next-task/SKILL.md
+++ b/skills/work-next-task/SKILL.md
@@ -14,7 +14,7 @@ One iteration of a ralph loop over `.claude/milestones/<slug>/tasks.json`. Pick,
 Composes with:
 
 - `/loop /work-next-task` — in-session convenience (carries session context, less Ralph-pure)
-- `scripts/ralph.sh` — headless shell harness for capital-R Ralph runs (fresh process per iteration, file-only state)
+- `./skills/work-next-task/scripts/ralph.sh` — headless shell harness for capital-R Ralph runs, run from repo root (fresh process per iteration, file-only state)
 
 ## Contract
 

--- a/skills/work-next-task/scripts/ralph.sh
+++ b/skills/work-next-task/scripts/ralph.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# ralph.sh — reference shell harness for capital-R Ralph runs of /work-next-task.
+#
+# Runs /work-next-task in a loop. Fresh claude process per iteration so no conversation
+# state is carried across — all state lives in tasks.json + progress.md. Exits on
+# completion token, halt token, or iteration cap.
+#
+# Usage:
+#   ./scripts/ralph.sh                    # 50 iterations, standard mode (single-worker)
+#   ./scripts/ralph.sh 100                # 100 iterations, standard mode
+#   ./scripts/ralph.sh 100 --autonomous   # autonomous mode (push + draft PRs, multi-worker-safe)
+#
+# Exit codes:
+#   0  MILESTONE_COMPLETE
+#   1  HALT (drift, retry cap, or no unblocked tasks — human review)
+#   2  reached iteration cap without completion
+
+set -euo pipefail
+
+MAX="${1:-50}"
+AUTONOMOUS_FLAG=""
+if [[ "${2:-}" == "--autonomous" ]]; then
+  AUTONOMOUS_FLAG="--autonomous"
+fi
+
+for ((i=1; i<=MAX; i++)); do
+  echo "=== iteration $i/$MAX ==="
+
+  result=$(claude -p --permission-mode acceptEdits "/work-next-task ${AUTONOMOUS_FLAG}")
+  echo "$result"
+
+  if [[ "$result" == *"<promise>MILESTONE_COMPLETE</promise>"* ]]; then
+    echo "=== milestone complete ==="
+    exit 0
+  fi
+
+  if [[ "$result" == *"<promise>HALT</promise>"* ]]; then
+    echo "=== halted — human review needed ==="
+    exit 1
+  fi
+done
+
+echo "=== reached iteration cap ($MAX) without completion ==="
+exit 2

--- a/skills/work-next-task/scripts/ralph.sh
+++ b/skills/work-next-task/scripts/ralph.sh
@@ -5,10 +5,10 @@
 # state is carried across — all state lives in tasks.json + progress.md. Exits on
 # completion token, halt token, or iteration cap.
 #
-# Usage:
-#   ./scripts/ralph.sh                    # 50 iterations, standard mode (single-worker)
-#   ./scripts/ralph.sh 100                # 100 iterations, standard mode
-#   ./scripts/ralph.sh 100 --autonomous   # autonomous mode (push + draft PRs, multi-worker-safe)
+# Usage (run from repo root):
+#   ./skills/work-next-task/scripts/ralph.sh                    # 50 iterations, standard mode (single-worker)
+#   ./skills/work-next-task/scripts/ralph.sh 100                # 100 iterations, standard mode
+#   ./skills/work-next-task/scripts/ralph.sh 100 --autonomous   # autonomous mode (push + draft PRs, multi-worker-safe)
 #
 # Exit codes:
 #   0  MILESTONE_COMPLETE

--- a/skills/work-next-task/scripts/ralph.sh
+++ b/skills/work-next-task/scripts/ralph.sh
@@ -5,28 +5,51 @@
 # state is carried across — all state lives in tasks.json + progress.md. Exits on
 # completion token, halt token, or iteration cap.
 #
-# Usage (run from repo root):
-#   ./skills/work-next-task/scripts/ralph.sh                    # 50 iterations, standard mode (single-worker)
-#   ./skills/work-next-task/scripts/ralph.sh 100                # 100 iterations, standard mode
-#   ./skills/work-next-task/scripts/ralph.sh 100 --autonomous   # autonomous mode (push + draft PRs, multi-worker-safe)
+# Usage (run from repo root; args accepted in any order):
+#   ./skills/work-next-task/scripts/ralph.sh                              # 50 iterations, standard mode
+#   ./skills/work-next-task/scripts/ralph.sh 100                          # 100 iterations, standard mode
+#   ./skills/work-next-task/scripts/ralph.sh 100 --autonomous             # autonomous mode (push + draft PRs, multi-worker-safe)
+#   ./skills/work-next-task/scripts/ralph.sh --autonomous --slug my-ms    # autonomous, explicit slug (required when multiple milestones exist)
+#
+# Flags:
+#   --autonomous        enable push + draft PR discipline; suppresses interactive prompts in the skill
+#   --slug <name>       disambiguate which .claude/milestones/<slug>/ to work against (passed through to /work-next-task)
+#   <integer>           iteration cap (default 50)
 #
 # Exit codes:
 #   0  MILESTONE_COMPLETE
-#   1  HALT (drift, retry cap, or no unblocked tasks — human review)
+#   1  HALT (drift, retry cap, or no unblocked tasks; human review)
 #   2  reached iteration cap without completion
+#   64 usage error
 
 set -euo pipefail
 
-MAX="${1:-50}"
+MAX=50
 AUTONOMOUS_FLAG=""
-if [[ "${2:-}" == "--autonomous" ]]; then
-  AUTONOMOUS_FLAG="--autonomous"
-fi
+SLUG_ARG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --autonomous) AUTONOMOUS_FLAG="--autonomous"; shift ;;
+    --slug)
+      if [[ -z "${2:-}" ]]; then
+        echo "error: --slug requires a value" >&2; exit 64
+      fi
+      SLUG_ARG="--slug $2"; shift 2 ;;
+    [0-9]*) MAX="$1"; shift ;;
+    *) echo "error: unknown arg: $1" >&2; exit 64 ;;
+  esac
+done
+
+# Build the skill invocation, omitting empty flags to avoid trailing whitespace.
+CMD="/work-next-task"
+[[ -n "$AUTONOMOUS_FLAG" ]] && CMD="$CMD $AUTONOMOUS_FLAG"
+[[ -n "$SLUG_ARG" ]] && CMD="$CMD $SLUG_ARG"
 
 for ((i=1; i<=MAX; i++)); do
   echo "=== iteration $i/$MAX ==="
 
-  result=$(claude -p --permission-mode acceptEdits "/work-next-task ${AUTONOMOUS_FLAG}")
+  result=$(claude -p --permission-mode acceptEdits "$CMD")
   echo "$result"
 
   if [[ "$result" == *"<promise>MILESTONE_COMPLETE</promise>"* ]]; then

--- a/skills/work-next-task/scripts/ralph.sh
+++ b/skills/work-next-task/scripts/ralph.sh
@@ -49,7 +49,10 @@ CMD="/work-next-task"
 for ((i=1; i<=MAX; i++)); do
   echo "=== iteration $i/$MAX ==="
 
-  result=$(claude -p --permission-mode acceptEdits "$CMD")
+  if ! result=$(claude -p --permission-mode acceptEdits "$CMD"); then
+    echo "=== iteration $i: claude invocation failed, continuing ==="
+    continue
+  fi
   echo "$result"
 
   if [[ "$result" == *"<promise>MILESTONE_COMPLETE</promise>"* ]]; then


### PR DESCRIPTION
## Summary

- Adds `milestone-to-tasks` (generator) and `work-next-task` (worker) skills, implementing a Ralph-style autonomous loop driven by a GitHub milestone.
- `milestone-to-tasks` emits a structured `tasks.json` + seeded `progress.md` under `.claude/milestones/<slug>/`, with hybrid priority + `blocked_by` inference (explicit signals first, LLM fallback, user confirms).
- `work-next-task` runs one iteration: fetch (autonomous), select, drift-check, claim, work, verify, two-commit discipline, exit. Standard mode is single-worker local-only; `--autonomous` opts into push + draft PR + multi-worker discipline (fetch-before-select / push-after-claim).
- Ships `scripts/ralph.sh` as the capital-R Ralph shell harness using `claude -p` per iteration, driven by completion tokens (`MILESTONE_COMPLETE`, `HALT`).
- Adds `explorations/milestone-ralph-vs-aihero.md` — capability comparison vs. the AIHero / Huntley Ralph conventions, plus a roadmap-implications section capturing the v1.x / follow-up items (sandbox/AFK variant, PRD-to-tasks generator, soft safety check, etc.).

## Design rationale

Full design tree was walked via a `/grill-me` session. Key decisions, briefly:

- **Two skills, contract-based.** Generator and worker are separable; worker consumes a canonical `tasks.json` schema so any future generator (PRD-to-tasks, etc.) composes with it.
- **JSON tasks.json, markdown progress.md.** Follows Anthropic's finding that models are less likely to clobber JSON than markdown (https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents). JSON gets the structured state; markdown gets the free-form running log.
- **tasks.json is a living spec, not a plan.** Mid-flight edits (flipping `done → open` with revised steps, adding tasks, re-prioritizing) are first-class; the worker re-reads the file every iteration.
- **Ephemeral artifacts.** Worker prompts for cleanup when all tasks are `done`.
- **Concurrency:** standard mode is single-worker by contract; autonomous supports multi-worker via fetch-before-select / push-after-claim.

See the exploration doc for the full comparison vs. AIHero Ralph and the roadmap items.

## Test plan

- [ ] `shellcheck skills/work-next-task/scripts/ralph.sh` clean
- [ ] Read both `SKILL.md` files end-to-end for coherence and schema consistency
- [ ] Symlink both skills into `~/.claude/skills/` after merge; confirm `/milestone-to-tasks` and `/work-next-task` surface in Claude Code
- [ ] Dry-run `/milestone-to-tasks` against a small test milestone; verify the generated `tasks.json` schema matches the SKILL.md spec and the graph quiz surfaces priority/dep sources
- [ ] Run one iteration of `/work-next-task` in standard mode against a single-task test milestone; verify two-commit discipline and progress.md append-only behavior
- [ ] Run `scripts/ralph.sh 3` against the same test milestone; verify completion tokens drive harness exit correctly

## Follow-ups (not in this PR)

Tracked in both `SKILL.md` files and the exploration doc:

- Fully-unattended AFK / Docker sandbox variant (isolation, secrets, quotas, crash recovery, logs, AFK-skill integration)
- `prd-to-tasks` generator and a `/loop`-against-PRD-sub-issues variant
- v1.1 soft safety check for detecting accidental concurrent standard-mode workers
- Three-way merge `--refresh` if conservative-merge proves insufficient
- CI watch inside the autonomous loop