### PR TITLE
feat(skills): add pr-review-batching; revise pr-review Step 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Skills in this repo are symlinked into `~/.claude/skills/`, making them globally
 Changes to a skill file in the repo are immediately live — no copy or sync step. For the full three-tier sync architecture (repo, global, Cowork), see [Skill Management](workflows/skill-management.md).
 
 - [`/pr-review`](skills/pr-review/SKILL.md) — AI-assisted GitHub PR review with line-level draft comments
+- [`/pr-review-batching`](skills/pr-review-batching/SKILL.md): stage PR review comments as drafts on a pending review (never publishes); owns ensure-then-append and accidental-publish incident response
 - [`/memory-audit`](skills/memory-audit/SKILL.md) — reflective review, consolidation, and pruning of memory files; defaults to current project, offers a cross-project sweep for promotion candidates
 - [`/branch-cleanup`](skills/branch-cleanup/SKILL.md) — interactive local branch cleanup with PR cross-referencing
 - [`/grill-me`](skills/grill-me/SKILL.md) — stress-test a plan or design through relentless interrogation

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Skills in this repo are symlinked into `~/.claude/skills/`, making them globally
 Changes to a skill file in the repo are immediately live — no copy or sync step. For the full three-tier sync architecture (repo, global, Cowork), see [Skill Management](workflows/skill-management.md).
 
 - [`/pr-review`](skills/pr-review/SKILL.md) — AI-assisted GitHub PR review with line-level draft comments
-- [`/pr-review-batching`](skills/pr-review-batching/SKILL.md): stage PR review comments as drafts on a pending review (never publishes); owns ensure-then-append and accidental-publish incident response
+- [`/pr-review-batching`](skills/pr-review-batching/SKILL.md) - stage PR review comments as drafts on a pending review (never publishes); owns ensure-then-append and accidental-publish incident response
 - [`/memory-audit`](skills/memory-audit/SKILL.md) — reflective review, consolidation, and pruning of memory files; defaults to current project, offers a cross-project sweep for promotion candidates
 - [`/branch-cleanup`](skills/branch-cleanup/SKILL.md) — interactive local branch cleanup with PR cross-referencing
 - [`/grill-me`](skills/grill-me/SKILL.md) — stress-test a plan or design through relentless interrogation

--- a/skills/pr-review-batching/SKILL.md
+++ b/skills/pr-review-batching/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: pr-review-batching
+user-invocable: true
+description: >
+  Stages PR review comments as drafts on a GitHub pending review; never publishes. Owns two
+  operations: (1) ensure-then-append, which adds comments to an existing pending review or
+  creates one if none exists, without clobbering user-in-flight edits; (2) incident response,
+  which undoes an accidentally published review by deleting its visible comments and
+  recreating as pending.
+
+  ACTION-BOUNDARY TRIGGER: consult this skill before any `gh pr review` invocation or any
+  POST / DELETE on `/pulls/{n}/reviews`. This skill is the guard against publishing a review
+  when the user wanted drafts. Also triggers on phrases: "draft comment", "pending review",
+  "post this as a draft", "add to the review", "stage as a draft", or explicit
+  `/pr-review-batching`.
+---
+
+# PR Review Batching
+
+This skill owns the submission lifecycle for PR review comments. Every comment is staged as a
+draft on a pending review; the user submits manually. Claude never sets `event=COMMENT`,
+`event=APPROVE`, or `event=REQUEST_CHANGES`.
+
+Documented user convention (global `CLAUDE.md`):
+
+> Never post comments individually. Use pending review mechanism.
+> Present batch for confirmation; I submit manually to control review event type.
+
+---
+
+## Hard rules
+
+1. **Never submit a review.** Do not pass an `event` field on POST to
+   `/pulls/{n}/reviews`, and do not call `gh pr review` with `--comment`, `--approve`, or
+   `--request-changes`. Omitting `event` keeps the review in state `PENDING`.
+2. **Never PATCH an existing draft comment.** `PATCH /pulls/comments/{id}` is a blind
+   overwrite of whatever the user may be editing in the browser. Use delete-and-recreate.
+3. **Line numbers come from the file at the PR head SHA**, not diff offsets. Verify with
+   `gh api repos/{owner}/{repo}/contents/{path}?ref={head_sha}` if unsure.
+4. **Server is the source of truth.** Always sync from server before appending. The user may
+   have edited drafts in the browser since the last Claude-side write.
+
+---
+
+## Operation 1: ensure-then-append
+
+Use this flow to "add these N draft comments to the PR's pending review."
+
+### Step 1. Detect existing pending review
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{n}/reviews \
+  --jq '.[] | select(.state=="PENDING") | .id'
+```
+
+Outcomes:
+
+- **No output:** no pending review exists. Go to Step 2a.
+- **One id:** pending review exists. Go to Step 2b.
+- **Multiple ids:** unexpected. Stop and report to the user.
+
+### Step 2a. Create pending review (no existing)
+
+Write the accumulator to `/tmp/pr-review-batching-<pr-number>.json` in the shape below, then POST:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{n}/reviews \
+  --method POST \
+  --input /tmp/pr-review-batching-<pr-number>.json
+```
+
+Accumulator shape:
+
+```json
+{
+  "comments": [
+    {
+      "path": "src/foo.ts",
+      "start_line": 10,
+      "line": 15,
+      "start_side": "RIGHT",
+      "side": "RIGHT",
+      "body": "..."
+    }
+  ]
+}
+```
+
+For single-line comments, omit `start_line` and `start_side`. Do NOT include an `event` field.
+
+On success, delete the accumulator file. On failure, preserve it for debug.
+
+### Step 2b. Append to existing pending review (delete-and-recreate)
+
+GitHub has no safe idempotent append, so the append path is delete-and-recreate. Before doing
+anything, check whether the existing review has any comments:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{n}/reviews/{review_id}/comments --jq 'length'
+```
+
+If `0`: fall through to Step 2a (no race window, nothing to preserve).
+
+If `>= 1`: announce to the user (see Race-window protocol), then:
+
+1. **Fetch comment metadata via REST** (bodies, node_ids, paths):
+
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/{n}/reviews/{review_id}/comments
+   ```
+
+   REST omits `startLine`/`line` for pending comments, so metadata from REST alone is
+   incomplete for multi-line comments.
+
+2. **Enrich each via GraphQL** to recover the multi-line span:
+
+   ```bash
+   gh api graphql -f query='
+     query($id: ID!) {
+       node(id: $id) {
+         ... on PullRequestReviewComment {
+           path
+           line
+           startLine
+           side
+           startSide
+           body
+         }
+       }
+     }' -f id=<node_id>
+   ```
+
+3. **Build the accumulator** at `/tmp/pr-review-batching-<pr-number>.json` from GraphQL
+   output. Preserve every body verbatim, including any `\r\n` line endings; do not normalize.
+   This captures whatever edits the user made in the browser.
+
+4. **Append the new comment(s)** to the accumulator's `comments` array.
+
+5. **Delete the pending review.** This only works while state is still `PENDING`:
+
+   ```bash
+   gh api -X DELETE repos/{owner}/{repo}/pulls/{n}/reviews/{review_id}
+   ```
+
+6. **POST the new pending review** with the full accumulator:
+
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/{n}/reviews \
+     --method POST \
+     --input /tmp/pr-review-batching-<pr-number>.json
+   ```
+
+   No `event` field.
+
+7. **On success:** delete `/tmp/pr-review-batching-<pr-number>.json`. On failure: leave it in
+   place for debug inspection.
+
+8. **Announce done** to the user (see Race-window protocol).
+
+---
+
+## Operation 2: incident response
+
+Use when a review was accidentally submitted (state `COMMENTED`, `APPROVED`, or
+`CHANGES_REQUESTED`) instead of staged as drafts.
+
+### Step 1. Locate the published review
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{n}/reviews \
+  --jq '.[] | select(.state != "PENDING") | select(.user.login == "<current-user>") | .id'
+```
+
+### Step 2. Save the review's comments
+
+Before deleting anything, fetch bodies and positional metadata:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{n}/reviews/{review_id}/comments
+```
+
+Enrich each via the GraphQL `node(id: ...)` query from Operation 1 Step 2b.2.
+
+Build the standard accumulator at `/tmp/pr-review-batching-<pr-number>.json`.
+
+### Step 3. Delete the visible inline comments
+
+For each comment id:
+
+```bash
+gh api -X DELETE repos/{owner}/{repo}/pulls/comments/{comment_id}
+```
+
+### Step 4. Recreate as pending
+
+Run Operation 1 with the saved accumulator.
+
+### Step 5. Notify the user honestly
+
+The published review record itself cannot be deleted; only its inline comments can. The empty
+review shell (with its state and timestamp) remains on the PR timeline. Surface this:
+
+> Inline comments from the published review have been removed and recreated as drafts on a new
+> pending review. The original review record stays on the PR timeline as an empty shell;
+> GitHub does not allow deleting a submitted review. Apologies.
+
+---
+
+## Race-window protocol
+
+A delete-and-recreate cycle has a few-second window where the pending review does not exist.
+If the user is editing a draft comment in the browser during that window, their edit will
+target a deleted review and fail.
+
+Announce ONLY when the delete-and-recreate path is actually running, i.e. the existing pending
+review has at least one comment. When a pending review has zero comments (Operation 1 Step
+2a), skip the announce; there is no race window.
+
+**Before** (when Step 2b runs):
+
+> Syncing pending review now. Stay out of the PR UI until I confirm done.
+
+**After** (once Step 2b POST succeeds):
+
+> Sync done. OK to resume.
+
+Plain wording, no prefix or emoji, consistent across invocations. Announce and proceed; do not
+wait for acknowledgement, since the action was already approved.
+
+---
+
+## Technical notes
+
+- **Multi-line comments.** REST's `/reviews/{id}/comments` returns `position` and
+  `original_position` (end-of-span only) for pending comments; it does NOT return `startLine`
+  or `line`. Use the GraphQL `node(id: ...)` query for round-trip fidelity.
+- **CRLF handling.** GitHub may store bodies with `\r\n` after browser edits. Preserve what
+  the server returns verbatim; do not normalize line endings.
+- **Accumulator file.** `/tmp/pr-review-batching-<pr-number>.json`. Clean up on POST success;
+  preserve on failure. `/tmp` on macOS does not reliably auto-clean, so explicit cleanup
+  matters.
+- **Empty review shell.** Once a review has state `COMMENTED`, `APPROVED`, or
+  `CHANGES_REQUESTED`, the review record itself cannot be deleted via the API. Its inline
+  comments can be. Surface this honestly in incident response.
+- **Side field.** Default to `RIGHT` (changed file). `LEFT` refers to the base file
+  pre-change and is rare for draft review comments.
+- **`gh pr review` is disallowed in this skill.** Its flags (`--comment`, `--approve`,
+  `--request-changes`) all set a non-`PENDING` event. Always use `gh api .../reviews` without
+  `event` instead.
+
+---
+
+## Interaction with `pr-review`
+
+`skills/pr-review/SKILL.md` Step 9 ends with: "Want me to draft these as pending-review
+comments on the PR?" On confirmation it invokes this skill with the list of draft comments.
+`pr-review` never calls `gh pr review` or sets `event=` directly; that decision lives here.
+
+---
+
+## Out of scope
+
+- Pre-submit linting of draft bodies.
+- Standalone "sync from server" without an append.
+- Full CRUD on draft comments (PATCH is explicitly forbidden).
+- Cross-session persistence of the accumulator; the server is the source of truth.
+- Browser-only fallback when `gh` CLI is unavailable.

--- a/skills/pr-review-batching/SKILL.md
+++ b/skills/pr-review-batching/SKILL.md
@@ -280,6 +280,10 @@ wait for acknowledgement, since the action was already approved.
 
 ## Technical notes
 
+- **Line numbers, not diff positions.** Review-comment payloads use `line` and `start_line`
+  (file line numbers at the PR head SHA). The legacy `position` field (diff-hunk offset) is
+  not needed and is not used anywhere in this skill; do not reach for it even if older docs or
+  examples suggest otherwise.
 - **Multi-line comments.** REST's `/reviews/{id}/comments` returns `position` and
   `original_position` (end-of-span only) for pending comments; it does NOT return `startLine`
   or `line`. Use the GraphQL `node(id: ...)` query for round-trip fidelity.

--- a/skills/pr-review-batching/SKILL.md
+++ b/skills/pr-review-batching/SKILL.md
@@ -130,9 +130,46 @@ If `>= 1`: announce to the user (see Race-window protocol), then:
      }' -f id=<node_id>
    ```
 
-3. **Build the accumulator** at `/tmp/pr-review-batching-<pr-number>.json` from GraphQL
-   output. Preserve every body verbatim, including any `\r\n` line endings; do not normalize.
-   This captures whatever edits the user made in the browser.
+3. **Build the accumulator** at `/tmp/pr-review-batching-<pr-number>.json` from the GraphQL
+   output, translating field names to the REST review-comment payload schema. Preserve every
+   body verbatim, including any `\r\n` line endings; do not normalize. This captures whatever
+   edits the user made in the browser.
+
+   Required field mapping (GraphQL camelCase -> REST snake_case):
+
+   - `path` -> `path`
+   - `line` -> `line`
+   - `side` -> `side`
+   - `body` -> `body`
+   - `startLine` -> `start_line`
+   - `startSide` -> `start_side`
+
+   Omission rules for single-line comments: GraphQL returns `startLine: null` and
+   `startSide: null`. Omit `start_line` and `start_side` entirely from the accumulator object.
+   Do NOT send them as `null`, and do NOT leave them as camelCase keys.
+
+   Example accumulator entries built from GraphQL results:
+
+   ```json
+   {
+     "comments": [
+       {
+         "path": "src/example.ts",
+         "start_line": 18,
+         "line": 20,
+         "start_side": "RIGHT",
+         "side": "RIGHT",
+         "body": "Existing multi-line draft"
+       },
+       {
+         "path": "src/example.ts",
+         "line": 42,
+         "side": "RIGHT",
+         "body": "Existing single-line draft"
+       }
+     ]
+   }
+   ```
 
 4. **Append the new comment(s)** to the accumulator's `comments` array.
 

--- a/skills/pr-review-batching/SKILL.md
+++ b/skills/pr-review-batching/SKILL.md
@@ -192,7 +192,13 @@ If `>= 1`: announce to the user (see Race-window protocol), then:
 7. **On success:** delete `/tmp/pr-review-batching-<pr-number>.json`. On failure: leave it in
    place for debug inspection.
 
-8. **Announce done** to the user (see Race-window protocol).
+   If Step 6 POST failed after Step 5 DELETE succeeded, the pending review no longer exists
+   on the server and the user's prior drafts are unrecoverable from GitHub. Tell the user
+   explicitly (do NOT send the Race-window "Sync done" message); point them at the preserved
+   accumulator at `/tmp/pr-review-batching-<pr-number>.json`, which can be retried with
+   `gh api repos/{owner}/{repo}/pulls/{n}/reviews --method POST --input <path>`.
+
+8. **Announce done** to the user (see Race-window protocol). Only on POST success.
 
 ---
 

--- a/skills/pr-review-batching/SKILL.md
+++ b/skills/pr-review-batching/SKILL.md
@@ -203,10 +203,22 @@ Use when a review was accidentally submitted (state `COMMENTED`, `APPROVED`, or
 
 ### Step 1. Locate the published review
 
+List the current user's non-pending reviews, newest first:
+
 ```bash
 gh api repos/{owner}/{repo}/pulls/{n}/reviews \
-  --jq '.[] | select(.state != "PENDING") | select(.user.login == "<current-user>") | .id'
+  --jq '[.[] | select(.state != "PENDING") | select(.user.login == "<current-user>")]
+        | sort_by(.submitted_at) | reverse
+        | .[] | {id, state, submitted_at, body}'
 ```
+
+If this returns more than one review, **do not guess.** Present the list to the user
+(id, state, submitted_at, first line of body) and ask which one to treat as the accidental
+publish. The default selection is the most recent, but require explicit user confirmation
+before proceeding; Operation 2 is destructive (Step 3 deletes inline comments), and the
+wrong `review_id` damages an unrelated review.
+
+Record the confirmed `review_id` and use it for the remaining steps.
 
 ### Step 2. Save the review's comments
 

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -299,32 +299,26 @@ One or two sentences stating the concern and why it matters.
 
 ---
 
-## Step 9: Offer to post to GitHub
+## Step 9: Offer to stage as drafts
 
 After presenting the review, ask:
 
-> Want me to post any of these to the PR? I can post all of them, specific ones, or just a
-> general review comment.
+> Want me to draft these as pending-review comments on the PR? I'll stage them as drafts; you
+> submit the review manually when you're ready.
 
-If yes, use `gh pr review` for general comments or the GitHub API for inline line-level comments:
+If the user confirms, hand off to the `pr-review-batching` skill with the list of comments
+(path, line / start_line, side / start_side, body per comment). That skill owns the
+submission lifecycle: detecting an existing pending review, appending without clobbering
+user-in-flight edits, and incident response if a review gets published by mistake.
 
-```bash
-# General review comment (non-approving)
-gh pr review <URL> --comment --body "<review body>"
+**Do NOT call `gh pr review` or `gh api .../pulls/.../reviews` with an `event` field from this
+skill.** Any `event=COMMENT | APPROVE | REQUEST_CHANGES` publishes the review immediately,
+which violates the user's convention that they submit manually. See
+`skills/pr-review-batching/SKILL.md` for the runbook.
 
-# Inline review (requires building a review via the API with per-file comment positions)
-gh api repos/{owner}/{repo}/pulls/{number}/reviews \
-  --method POST \
-  --field body="<overall comment>" \
-  --field event="COMMENT" \
-  --field "comments[][path]=src/foo.ts" \
-  --field "comments[][position]=<diff position>" \
-  --field "comments[][body]=<comment text>"
-```
-
-Note: GitHub inline comments use *diff position* (line offset within the diff hunk), not file line
-numbers. Calculate the diff position from `gh pr diff` output when posting inline. If this is
-complex, offer to post a consolidated general comment instead.
+If the user wants something other than a batched draft review (for example, a standalone
+non-inline review comment, or an explicit approval), confirm the intent explicitly before
+taking any action that changes PR state.
 
 ---
 


### PR DESCRIPTION
## Summary

- New skill `pr-review-batching` owns the submission lifecycle for PR review comments. Stages every comment as a draft on a pending review and never publishes. Two operations: ensure-then-append (delete-and-recreate to safely append without clobbering user-in-flight browser edits), and incident response (undo accidental publish, with honest disclosure about the residual empty review shell).
- `pr-review` Step 9 rewritten as ask-first gate that hands off to `pr-review-batching`. Removed the prior `event=COMMENT` example and `gh pr review --comment` invocation that were steering directly into the publish path.
- README skill index updated.

Closes #7.

## Test plan

- [ ] Run `pr-review` on a real PR end-to-end and confirm Step 9 prompts for batched-draft staging rather than publishing.
- [ ] First batch of comments creates a pending review (Operation 1, Step 2a path).
- [ ] Edit one of the draft bodies in the GitHub UI, then add another comment via Claude. Confirm the prior body edit is preserved after the delete-and-recreate sync (Operation 1, Step 2b path).
- [ ] Multi-line comment round-trips through GraphQL enrichment with start_line and line preserved.
- [ ] Race-window announce / done messages fire only when an existing pending review has at least one comment.
- [ ] Symlink `~/.claude/skills/pr-review-batching -> ~/dev/claude-workflows/skills/pr-review-batching` after merge.