### PR TITLE
docs: capture findings from gh-api-reply-errors incident

### DIFF
--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -147,6 +147,14 @@ On correction (user or self-caught): propose `CLAUDE.md` update **immediately, b
 
 ---
 
+## External API Calls
+
+- **Probe once, then parallelize.** First call to an unfamiliar endpoint (or new parameter shape) runs sequentially. Only parallelize siblings after that probe succeeds. Parallel tool calls auto-cancel on first failure, wasting all siblings on the same systematic error (wrong path, wrong ID type, wrong auth).
+- **Prefer `gh api --jq '<filter>'` over `gh api ... | jq '<filter>'`.** The `--jq` flag applies only on success; API errors print raw to stderr, preserving the real failure. External `jq` processes error HTML identically to JSON, producing parse errors that mask the underlying issue. For first probes, omit jq entirely to see the raw response.
+- **GraphQL node IDs ≠ REST numeric IDs.** Base64 node IDs (e.g. `PRRC_kwDO...`) returned by GraphQL are not interchangeable with numeric IDs required by REST endpoints. Translate deliberately, or stay in one API surface for the full read-mutate cycle.
+
+---
+
 ## Git Conventions
 
 - [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): description`. Scope optional but preferred.

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -193,10 +193,11 @@ After pushing a new PR, watch for bot review comments (Copilot, Codex, etc.).
 ## PR Review Conventions
 
 **Addressing feedback** (human and bot):
-- Accepted: reply `:zap: <commit hash>`, minimal commentary. Resolve the thread.
+- Accepted: reply `:zap: <commit hash>`, minimal commentary.
 - Rejected: reply with brief rationale.
 - Batch trivial fixes; non-trivial gets its own commit.
-- **Resolve threads via `resolveReviewThread` GraphQL mutation** - never `minimizeComment`.
+- **Resolve every thread with a definitive reply, after that reply is published.** Applies to both accepted and rejected. If replies are staged as pending review drafts, wait until the user submits the review before resolving; resolving before publication leaves other reviewers seeing a resolved thread with no visible rationale (invisible dismissal). An open thread signals "still needs attention"; a resolved thread with no visible reply signals "invisible dismissal."
+- Use `resolveReviewThread` GraphQL mutation; never `minimizeComment`.
 
 **Posting reviews on my behalf:**
 - Never post comments individually. Use pending review mechanism.

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -237,6 +237,34 @@ gh api repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies \
 
 Note: the pull number is required in the path. The comment-level GET endpoint (`/pulls/comments/{id}`) omits it, but the reply POST does not; `/pulls/comments/{id}/replies` returns 404.
 
+### Resolving threads after reply
+
+After replying to bot review threads, resolve every thread that received a definitive reply (accepted or rejected). An open thread signals "still needs attention"; a replied-to rejection is definitively addressed and should be resolved too. Timing depends on how the reply was posted:
+
+- **Direct reply** (REST `/pulls/{n}/comments/{id}/replies`): reply is immediately published. Resolve right after posting.
+- **Staged as pending review draft** (via `pr-review-batching`): reply is only visible to the author until the user submits the review. Do NOT resolve until after submission. Resolving before publication leaves other reviewers seeing a resolved thread with no visible rationale (worse than silent dismissal).
+
+There is no technical guard; `resolveReviewThread` succeeds regardless of whether a reply exists or is published. The constraint is purely workflow correctness.
+
+Use the GraphQL mutation with the thread's node ID:
+
+```bash
+gh api graphql -f query='mutation {
+  resolveReviewThread(input: {threadId: "<PRRT_node_id>"}) {
+    thread { isResolved }
+  }
+}'
+```
+
+Batch multiple resolutions into a single GraphQL call using aliases:
+
+```bash
+gh api graphql -f query='mutation {
+  t1: resolveReviewThread(input: {threadId: "<id1>"}) { thread { isResolved } }
+  t2: resolveReviewThread(input: {threadId: "<id2>"}) { thread { isResolved } }
+}'
+```
+
 ---
 
 ## Step 7: Before you write a comment, verify it

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -219,7 +219,7 @@ The GraphQL query above returns **node IDs** (base64-encoded, e.g. `PRRC_kwDONPD
 2. **Fetch numeric IDs from REST** before replying:
 
    ```bash
-   gh api repos/{owner}/{repo}/pulls/{n}/comments \
+   gh api repos/{owner}/{repo}/pulls/{pull_number}/comments \
      --jq '.[] | {id, body: .body[:60], user: .user.login}'
    ```
 
@@ -241,7 +241,7 @@ Note: the pull number is required in the path. The comment-level GET endpoint (`
 
 After replying to bot review threads, resolve every thread that received a definitive reply (accepted or rejected). An open thread signals "still needs attention"; a replied-to rejection is definitively addressed and should be resolved too. Timing depends on how the reply was posted:
 
-- **Direct reply** (REST `/pulls/{n}/comments/{id}/replies`): reply is immediately published. Resolve right after posting.
+- **Direct reply** (REST `/pulls/{pull_number}/comments/{id}/replies`): reply is immediately published. Resolve right after posting.
 - **Staged as pending review draft** (via `pr-review-batching`): reply is only visible to the author until the user submits the review. Do NOT resolve until after submission. Resolving before publication leaves other reviewers seeing a resolved thread with no visible rationale (worse than silent dismissal).
 
 There is no technical guard; `resolveReviewThread` succeeds regardless of whether a reply exists or is published. The constraint is purely workflow correctness.

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -211,6 +211,32 @@ Preserve thread `id`, comment `id`, and comment `url` for linking findings back 
 
 If no bots have commented on the PR, note `No bot reviews present.` and move on — don't fabricate coverage.
 
+### ID type caveat
+
+The GraphQL query above returns **node IDs** (base64-encoded, e.g. `PRRC_kwDONPDiQc6585CE` for comments, `PRRT_kwDONPDiQc58mSmJ` for threads). REST endpoints for replying to comments require **numeric IDs**. Two options when addressing a thread:
+
+1. **Stay in GraphQL for mutations**: use `addPullRequestReviewComment` with `inReplyTo: <comment_node_id>` and `resolveReviewThread` with `threadId: <thread_node_id>`. No ID translation needed.
+2. **Fetch numeric IDs from REST** before replying:
+
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/{n}/comments \
+     --jq '.[] | {id, body: .body[:60], user: .user.login}'
+   ```
+
+   Then use the numeric `id` in the reply endpoint below.
+
+Option 1 is preferred when posting replies as part of a pending review (aligns with `pr-review-batching`). Option 2 is simpler for standalone thread replies outside a review.
+
+### Replying to review threads (REST)
+
+```bash
+# Reply to a specific review comment thread
+gh api repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies \
+  -f body=':zap: <commit_hash>'
+```
+
+Note: the pull number is required in the path. The comment-level GET endpoint (`/pulls/comments/{id}`) omits it, but the reply POST does not; `/pulls/comments/{id}/replies` returns 404.
+
 ---
 
 ## Step 7: Before you write a comment, verify it


### PR DESCRIPTION
## Summary

- Adds pr-review skill coverage for three GitHub-API gotchas surfaced during PR #787 bot triage: GraphQL node IDs vs REST numeric IDs, the pull-number-in-path requirement for the reply endpoint, and thread-resolution timing when replies are staged as drafts vs published directly.
- Adds a new `External API Calls` section to global `config/CLAUDE.md` capturing the general patterns (probe-once-then-parallelize, prefer `gh api --jq` over piped `jq`, node-ID vs numeric-ID incompatibility).
- Rewrites the PR Review Conventions `Resolve threads` bullet to cover both scope (accepted and rejected) and timing (after publication only).

All additions are documentation-only; no runtime code changes. Source exploration report lives locally at `explorations/gh-api-reply-errors-report.md` and is intentionally not included.

## Test plan

- [ ] Review both files render cleanly in GitHub markdown preview
- [ ] No em-dashes introduced (global CLAUDE.md rule)
- [ ] Skill additions slot coherently into existing Step 6 subsection structure
- [ ] CLAUDE.md `External API Calls` section sits between Tool Permissions and Git Conventions as intended