### PR TITLE
docs(CLAUDE.md): trim to under 200 lines

### DIFF
--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -2,8 +2,6 @@
 
 Personal defaults applied across all sessions and projects. Local `CLAUDE.md` files take precedence.
 
----
-
 ## Tone and Behavior
 
 - Be extremely concise. Sacrifice formality and grammar (but not clarity or meaning) for concision. Short summaries over extended breakdowns.
@@ -11,23 +9,17 @@ Personal defaults applied across all sessions and projects. Local `CLAUDE.md` fi
 - When uncertain about intent or direction, ask. Keep asking until ambiguity is fully resolved - don't guess.
 - **No em dashes anywhere.** Applies to chat output, PR comments, commit messages, code comments, documentation, everything. Use hyphens, commas, or semicolons.
 
----
-
 ## Agentic Workflow
 
 **Session start**: Orient to the project first - check lockfile, `.nvmrc`, build scripts to determine package manager and toolchain. Never assume `npm`.
 
 Standard loop: **Plan -> Implement -> Test -> Commit**. Pause at each phase boundary. Within a phase, work autonomously unless you hit ambiguity or an uncovered decision point.
 
----
-
 ## PR Decomposition
 
 - **Small, independently mergeable PRs** - one shippable unit per PR. Tests pass, no dead code, no partial features visible to users. Feature flags and foundational types are often independently mergeable first.
 - **Sequential PRs to main** is the default. Each merges independently; next PR starts from updated main.
 - **Stacked PRs** only when changes are genuinely interdependent. Rebasing overhead isn't worth it when work can be sequential.
-
----
 
 ## Concurrent Workstreams
 
@@ -39,8 +31,6 @@ When preparing parallel work (multiple Claude sessions, AFK periods, handoffs):
 - **Rename branch when scope changes.** Worktree directory name is immutable - flag the mismatch but don't try to fix it.
 - **Before going AFK**: push all branches, open PRs (draft if needed), leave clear next-step notes.
 - **Don't force concurrency.** If the dependency chain is linear, sequential is faster.
-
----
 
 ## Plan Mode
 
@@ -66,8 +56,6 @@ Before implementing against an existing plan:
 
 For each issue found: describe concretely with file/line references, present 2-3 options (including "do nothing"), evaluate effort/risk/impact, recommend one, ask before proceeding.
 
----
-
 ## Testing - Red/Green/Refactor TDD
 
 Follow classic TDD universally:
@@ -80,15 +68,11 @@ Follow classic TDD universally:
 
 **Bug fixes**: regression test first (red), then fix (green). Applies to bugs from development, CI, or review feedback alike.
 
----
-
 ## Definition of Done
 
 - **Validate before pushing.** Tests pass, typecheck clean, lint clean. Full suite before push. Applies even for "low-risk" changes.
 - **Non-code changes still require validation.** CI workflows, config - use available tooling (actionlint, yamllint, schema checks) or review against specs.
 - **No untracked shortcuts.** No cut corners without documented tradeoffs and follow-up plan.
-
----
 
 ## Engineering Preferences
 
@@ -99,8 +83,6 @@ Follow classic TDD universally:
 - **Explicit over clever**
 - **Readable and maintainable** over terse
 
----
-
 ## Code Style
 
 - Descriptive, complete-word names; minimize abbreviations
@@ -108,8 +90,6 @@ Follow classic TDD universally:
 - Comments only when: purpose is non-obvious, deviating from standard approach, documenting a gotcha that can't be eliminated via code/types. Never restate what names already say. Explain **why**, not **what**.
 - Future work comments: `// TODO: description (#issue)`. Always greppable `TODO` prefix - no freeform "see #123".
 - **Markdown tables:** spaces on both sides of every `|` separator. Enforced by markdownlint MD060.
-
----
 
 ## Self-Correction Loop
 
@@ -120,14 +100,6 @@ On correction (user or self-caught): propose `CLAUDE.md` update **immediately, b
 - **Target**: global `CLAUDE.md` if broadly applicable; most local `CLAUDE.md` otherwise
 - **Process**: (1) stop task (2) propose rule + reasoning (3) apply on confirmation (4) resume
 
-### Follow-ups (remove once resolved)
-
-- Custom `/correct` skill - one-command trigger for corrections
-- Session-end hook prompting correction review
-- Session-start memory report for relevance calibration
-
----
-
 ## Memory Hygiene
 
 - **Index descriptions: specific and filterable** - name feature, issue number, or domain. No vague descriptions.
@@ -136,8 +108,6 @@ On correction (user or self-caught): propose `CLAUDE.md` update **immediately, b
 - **Delete shipped/resolved/obsolete memories.** Remove file and MEMORY.md entry.
 - **Project context -> memory. Global rules -> CLAUDE.md.** Promote feedback memories useful across 2+ sessions.
 
----
-
 ## Tool Permissions
 
 - **Read-only: never prompt.** Any command that only reads state (`git diff`, `gh pr view`, `grep`, `ls`, `cat`, version checks, etc.). All contexts.
@@ -145,15 +115,11 @@ On correction (user or self-caught): propose `CLAUDE.md` update **immediately, b
 - **Write/destructive/irreversible: ask first.** `git`/`gh` writes, file deletions, state-modifying commands, side-effecting API calls.
 - Local `CLAUDE.md` may add project-specific permissions or restrictions.
 
----
-
 ## External API Calls
 
 - **Probe once, then parallelize.** First call to an unfamiliar endpoint (or new parameter shape) runs sequentially. Only parallelize siblings after that probe succeeds. Parallel tool calls auto-cancel on first failure, wasting all siblings on the same systematic error (wrong path, wrong ID type, wrong auth).
 - **Prefer `gh api --jq '<filter>'` over `gh api ... | jq '<filter>'`.** The `--jq` flag applies only on success; API errors print raw to stderr, preserving the real failure. External `jq` processes error HTML identically to JSON, producing parse errors that mask the underlying issue. For first probes, omit jq entirely to see the raw response.
 - **GraphQL node IDs ≠ REST numeric IDs.** Base64 node IDs (e.g. `PRRC_kwDO...`) returned by GraphQL are not interchangeable with numeric IDs required by REST endpoints. Translate deliberately, or stay in one API surface for the full read-mutate cycle.
-
----
 
 ## Git Conventions
 
@@ -166,8 +132,6 @@ On correction (user or self-caught): propose `CLAUDE.md` update **immediately, b
 - **Start from fresh main.** Fetch, update, branch before new work.
 - **Never amend with open PR.** Creates force-push, loses review context. Always new commit.
 
----
-
 ## CI Watch
 
 After pushing to any PR (including drafts), proactively monitor CI:
@@ -178,8 +142,6 @@ After pushing to any PR (including drafts), proactively monitor CI:
 - **CI is authoritative** - local validation is necessary but not sufficient.
 - **Run CI watch and bot review triage concurrently** after each push.
 
----
-
 ## Bot PR Review Triage
 
 After pushing a new PR, watch for bot review comments (Copilot, Codex, etc.).
@@ -187,8 +149,6 @@ After pushing a new PR, watch for bot review comments (Copilot, Codex, etc.).
 **Evaluate automatically:** read all comments, verify each claim, categorize (accept/reject/nuance), present concise recommendation per comment.
 
 **Act only with explicit authorization:** batch trivial fixes into one commit, reply per review feedback conventions below. Flag non-trivial scope separately.
-
----
 
 ## PR Review Conventions
 


### PR DESCRIPTION
## Summary

- Drop section dividers (`---`) between `##` headings; headings already delimit sections.
- Remove the "Follow-ups (remove once resolved)" subsection from Self-Correction Loop. Items are now tracked as discrete issues: #12, #13, #14.
- 204 -> 164 lines, no content loss.

## Test plan

- [ ] Confirm symlink `~/.claude/CLAUDE.md -> config/CLAUDE.md` still resolves.
- [ ] Skim rendered markdown for readability without dividers.