### PR TITLE
docs(CLAUDE.md): add author review guidance convention

### DIFF
--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -165,14 +165,14 @@ After pushing a new PR, watch for bot review comments (Copilot, Codex, etc.).
 
 ## Author Review Guidance
 
-When asked, post review-guidance comments on our own PRs to help peer reviewers navigate the changes. Two parts:
+When asked, post review-guidance comments on our own PRs to help peer reviewers navigate the changes. Everything ships as a **single review submission** with the walkthrough as the review body and inline comments threaded below it.
 
-**Walkthrough comment** (top-level, posted first):
+**Walkthrough** (the review body):
 - One-paragraph summary of what changed and why.
 - Ordered list of files/areas to review, in suggested reading order. Each entry: file path, one sentence on what changed there, and why that order helps comprehension.
 - Call out anything the reviewer should *not* spend time on (e.g., mechanical renames, generated code).
 
-**Inline comments** (on specific diff lines):
+**Inline comments** (threaded under the walkthrough, on specific diff lines):
 - Prefix every inline comment with :notebook: so reviewers can visually distinguish author guidance from review feedback.
 - **When to add:** dense logic (regex, merge semantics), intentional tradeoffs (tech debt, relaxed assertions), subtle constraints, anything where "why did they do it this way?" is a predictable question.
 - **When not to:** obvious changes, trivial additions, anything the PR description or walkthrough already covers.
@@ -180,6 +180,6 @@ When asked, post review-guidance comments on our own PRs to help peer reviewers 
 - Keep each comment to one or two sentences. Link to PRD/issue if the context lives there. If it needs more, the code needs a real comment instead.
 
 **Mechanics:**
-- Stage as pending review drafts (pr-review-batching skill). Never post individually.
+- Stage as pending review drafts (pr-review-batching skill). The walkthrough goes in the review body; inline comments attach to diff lines. All submitted as one review.
 - Present the batch for confirmation before posting, same as any other review.
 - Don't duplicate information already in the PR description or commit messages; reference them instead.

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -162,3 +162,22 @@ After pushing a new PR, watch for bot review comments (Copilot, Codex, etc.).
 **Posting reviews on my behalf:**
 - Never post comments individually. Use pending review mechanism.
 - Present batch for confirmation; I submit manually to control review event type.
+
+## Author Review Guidance
+
+When asked, post review-guidance comments on our own PRs to help peer reviewers navigate the changes. Two parts:
+
+**Walkthrough comment** (top-level, posted first):
+- One-paragraph summary of what changed and why.
+- Ordered list of files/areas to review, in suggested reading order. Each entry: file path, one sentence on what changed there, and why that order helps comprehension.
+- Call out anything the reviewer should *not* spend time on (e.g., mechanical renames, generated code).
+
+**Inline comments** (on specific diff lines):
+- Preempt "why?" questions: non-obvious decisions, subtle constraints, intentional deviations from convention.
+- Flag risk: "this is the tricky part", "correctness depends on X invariant".
+- Keep each comment to one or two sentences. If it needs more, the code needs a real comment instead.
+
+**Mechanics:**
+- Use the pending review mechanism (never post individually).
+- Present the batch for confirmation before posting, same as any other review.
+- Don't duplicate information already in the PR description or commit messages; reference them instead.

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -174,11 +174,12 @@ When asked, post review-guidance comments on our own PRs to help peer reviewers 
 
 **Inline comments** (on specific diff lines):
 - Prefix every inline comment with :notebook: so reviewers can visually distinguish author guidance from review feedback.
-- Preempt "why?" questions: non-obvious decisions, subtle constraints, intentional deviations from convention.
+- **When to add:** dense logic (regex, merge semantics), intentional tradeoffs (tech debt, relaxed assertions), subtle constraints, anything where "why did they do it this way?" is a predictable question.
+- **When not to:** obvious changes, trivial additions, anything the PR description or walkthrough already covers.
 - Flag risk: "this is the tricky part", "correctness depends on X invariant".
-- Keep each comment to one or two sentences. If it needs more, the code needs a real comment instead.
+- Keep each comment to one or two sentences. Link to PRD/issue if the context lives there. If it needs more, the code needs a real comment instead.
 
 **Mechanics:**
-- Use the pending review mechanism (never post individually).
+- Stage as pending review drafts (pr-review-batching skill). Never post individually.
 - Present the batch for confirmation before posting, same as any other review.
 - Don't duplicate information already in the PR description or commit messages; reference them instead.

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -173,6 +173,7 @@ When asked, post review-guidance comments on our own PRs to help peer reviewers 
 - Call out anything the reviewer should *not* spend time on (e.g., mechanical renames, generated code).
 
 **Inline comments** (on specific diff lines):
+- Prefix every inline comment with :notebook: so reviewers can visually distinguish author guidance from review feedback.
 - Preempt "why?" questions: non-obvious decisions, subtle constraints, intentional deviations from convention.
 - Flag risk: "this is the tricky part", "correctness depends on X invariant".
 - Keep each comment to one or two sentences. If it needs more, the code needs a real comment instead.


### PR DESCRIPTION
## Summary
- Adds a new "Author Review Guidance" section to CLAUDE.md
- Defines two comment types: a top-level walkthrough (reading order, what changed where, what to skip) and inline comments on specific diff lines (non-obvious decisions, risk flags)
- On-request only, uses the pending review mechanism, presented for confirmation before posting

## Test plan
- [ ] Review rendered markdown for clarity
- [ ] Try it on a real PR to validate the walkthrough + inline format