### PR TITLE
docs(CLAUDE.md): align agentic loop with TDD convention

### DIFF
--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -13,7 +13,7 @@ Personal defaults applied across all sessions and projects. Local `CLAUDE.md` fi
 
 **Session start**: Orient to the project first - check lockfile, `.nvmrc`, build scripts to determine package manager and toolchain. Never assume `npm`.
 
-Standard loop: **Plan -> Implement -> Test -> Commit**. Pause at each phase boundary. Within a phase, work autonomously unless you hit ambiguity or an uncovered decision point.
+Standard loop: **Plan -> Implement (red/green/refactor) -> Validate -> Commit**. Pause at each phase boundary. Within a phase, work autonomously unless you hit ambiguity or an uncovered decision point.
 
 **Offload to subagents early.** If a task has 3+ independent subtasks (separate files, unrelated searches, parallel investigations), spawn subagents rather than working sequentially in the main thread. Reserve the main thread for synthesis, decisions, and sequencing.
 


### PR DESCRIPTION
## Summary
- Replaces "Plan -> Implement -> Test -> Commit" with "Plan -> Implement (red/green/refactor) -> Validate -> Commit"
- Resolves contradiction where the loop implied tests-after-implementation while the Testing section requires TDD universally
- "Validate" maps to the existing Definition of Done section (tests pass, typecheck, lint)

## Test plan
- [ ] Verify no remaining contradiction between Agentic Workflow and Testing sections