### PR TITLE
docs(CLAUDE.md): refine review feedback conventions

### DIFF
--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -158,7 +158,7 @@ After pushing a new PR, watch for bot review comments (Copilot, Codex, etc.).
 - Accepted: reply `:zap: <commit hash>`, minimal commentary.
 - Rejected: reply with brief rationale.
 - Batch trivial fixes; non-trivial gets its own commit.
-- **Only resolve threads we authored.** Reviewer threads (human or bot) stay open until the reviewer resolves them; the onus to accept and resolve is on the person who raised the concern.
+- **Only resolve threads we authored.** Reviewer threads (human and bot) stay open after we reply so human reviewers can see what was flagged, how it was addressed, and weigh in if needed.
 - For our own threads: resolve after the reply is published. If replies are staged as pending review drafts, wait until the review is submitted before resolving.
 - Use `resolveReviewThread` GraphQL mutation; never `minimizeComment`.
 

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -158,7 +158,8 @@ After pushing a new PR, watch for bot review comments (Copilot, Codex, etc.).
 - Accepted: reply `:zap: <commit hash>`, minimal commentary.
 - Rejected: reply with brief rationale.
 - Batch trivial fixes; non-trivial gets its own commit.
-- **Resolve every thread with a definitive reply, after that reply is published.** Applies to both accepted and rejected. If replies are staged as pending review drafts, wait until the user submits the review before resolving; resolving before publication leaves other reviewers seeing a resolved thread with no visible rationale (invisible dismissal). An open thread signals "still needs attention"; a resolved thread with no visible reply signals "invisible dismissal."
+- **Only resolve threads we authored.** Reviewer threads (human or bot) stay open until the reviewer resolves them; the onus to accept and resolve is on the person who raised the concern.
+- For our own threads: resolve after the reply is published. If replies are staged as pending review drafts, wait until the review is submitted before resolving.
 - Use `resolveReviewThread` GraphQL mutation; never `minimizeComment`.
 
 **Posting reviews on my behalf:**

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -156,7 +156,7 @@ After pushing a new PR, watch for bot review comments (Copilot, Codex, etc.).
 
 **Addressing feedback** (human and bot):
 - Accepted: reply `:zap: <commit hash>`, minimal commentary.
-- Rejected: reply with brief rationale.
+- Rejected: reply `:thought_balloon: <brief rationale>`.
 - Batch trivial fixes; non-trivial gets its own commit.
 - **Only resolve threads we authored.** Reviewer threads (human and bot) stay open after we reply so human reviewers can see what was flagged, how it was addressed, and weigh in if needed.
 - For our own threads: resolve after the reply is published. If replies are staged as pending review drafts, wait until the review is submitted before resolving.


### PR DESCRIPTION
## Summary
- Scope thread resolution to our own threads only; reviewer threads (human and bot) stay open so human reviewers can see what was flagged and how it was addressed
- Add `:thought_balloon:` prefix for rejected feedback replies, mirroring `:zap:` for accepted
- Simplifies the previous 3-sentence thread resolution bullet into two clear rules

## Test plan
- [ ] Verify guidance is unambiguous about thread ownership and emoji conventions