### PR TITLE
fix(skills): add missing user-invocable flag to memory-audit

### DIFF
--- a/skills/memory-audit/SKILL.md
+++ b/skills/memory-audit/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: memory-audit
+user-invocable: true
 description: >
   Review, consolidate, and prune a project's memory files. Merges duplicates, sharpens durable entries,
   retires dated ones, fixes relative time references, flags oversized files, surfaces promotion


### PR DESCRIPTION
## Summary
- Adds `user-invocable: true` to memory-audit SKILL.md frontmatter, consistent with all other active skills

## Test plan
- [ ] Verify memory-audit appears in `/skills` dialog after change