### PR TITLE
docs(internals): add sandbox mode evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ skills/        Skill drafts before deploying to ~/.claude/skills/
 - [Claude Code Internals — Cheat Sheet](internals/claude-code-internals-cheatsheet.md)
 - [Claude Code Internals — Presentation](internals/claude-code-internals-presentation.html) (Reveal.js, open in browser)
 - [Memory & Context Management](internals/memory-context-management.md) — how memory impacts token usage, two-tier loading, scaling guidelines
+- [Sandbox Mode Evaluation](internals/sandbox-mode-evaluation.md) — sandbox restrictions, auto-allow boundaries, risk assessment, native sandbox vs Docker
 
 ### Workflows
 

--- a/internals/sandbox-mode-evaluation.md
+++ b/internals/sandbox-mode-evaluation.md
@@ -6,18 +6,11 @@ How sandbox mode works, what it restricts, and when to use it vs. Docker isolati
 
 ## Enabling Sandbox Mode
 
-### Via settings.json (persistent, silent)
+### Via settings.json (persistent, schema can change)
 
-```json
-{
-  "sandbox": {
-    "enabled": true,
-    "mode": "auto-allow"
-  }
-}
-```
+Use `/sandbox` once, then inspect `~/.claude/settings.json` (or project `.claude/settings.json`) to see the exact keys your installed Claude Code version writes.
 
-No per-session prompts. Every session starts sandboxed automatically.
+This doc intentionally avoids pinning an unverified `sandbox.enabled`/`sandbox.mode` schema example.
 
 ### Via `/sandbox` command (interactive, ad-hoc)
 
@@ -37,12 +30,12 @@ Opens a menu to choose between auto-allow and regular permissions. Can toggle mi
 
 - Writes confined to CWD and subdirectories by default
 - Reads allowed broadly
-- Customizable via `sandbox.filesystem.allowWrite`
+- Extra write capability is typically granted through permission allowlist patterns (for example, `permissions.allow` entries), not a documented `sandbox.filesystem.*` key family
 
 ### Network
 
-- Proxy-based domain filtering; only approved domains reachable
-- New domains trigger prompts (or auto-block with `allowManagedDomainsOnly`)
+- Only approved domains are reachable by default
+- New domains trigger prompts (or deny in stricter permission modes)
 - Domain-level only, no TLS inspection
 
 ### Protected paths (never auto-approved)

--- a/internals/sandbox-mode-evaluation.md
+++ b/internals/sandbox-mode-evaluation.md
@@ -13,7 +13,8 @@ Use `/sandbox` once, then inspect settings at both scopes:
 - `~/.claude/settings.json` (global defaults)
 - `<repo>/.claude/settings.json` (project overrides, when present)
 
-This doc intentionally avoids pinning an unverified `sandbox.enabled`/`sandbox.mode` schema example because key names and structure can vary across Claude Code versions.
+This doc intentionally avoids pinning an unverified `sandbox.enabled`/`sandbox.mode` schema example.
+Key names and structure can vary across Claude Code versions.
 
 ### Via `/sandbox` command (interactive, ad-hoc)
 
@@ -33,7 +34,7 @@ Opens a menu to choose between auto-allow and regular permissions. Can toggle mi
 
 - Writes confined to CWD and subdirectories by default
 - Reads allowed broadly
-- Extra write capability is typically granted through permission allowlist patterns (for example, `permissions.allow` entries), not a documented `sandbox.filesystem.*` key family
+- Extra write capability is typically granted through permission allowlist patterns (for example, `permissions.allow` entries) rather than `sandbox.filesystem.*` configuration keys
 
 ### Network
 

--- a/internals/sandbox-mode-evaluation.md
+++ b/internals/sandbox-mode-evaluation.md
@@ -1,0 +1,103 @@
+# Claude Code Sandbox Mode Evaluation
+
+## Enabling Sandbox Mode
+
+### Via settings.json (persistent, silent)
+
+```json
+{
+  "sandbox": {
+    "enabled": true,
+    "mode": "auto-allow"
+  }
+}
+```
+
+No per-session prompts. Every session starts sandboxed automatically.
+
+### Via `/sandbox` command (interactive, ad-hoc)
+
+Opens a menu to choose between auto-allow and regular permissions. Can toggle mid-session.
+
+### Platform requirements
+
+- **macOS**: works out of the box (Seatbelt)
+- **Linux/WSL2**: install `bubblewrap` and `socat`
+- **WSL1**: not supported
+
+## What the Sandbox Restricts
+
+### Filesystem
+
+- Writes confined to CWD and subdirectories by default
+- Reads allowed broadly
+- Customizable via `sandbox.filesystem.allowWrite`
+
+### Network
+
+- Proxy-based domain filtering; only approved domains reachable
+- New domains trigger prompts (or auto-block with `allowManagedDomainsOnly`)
+- Domain-level only, no TLS inspection
+
+### Protected paths (never auto-approved)
+
+`.git`, `.claude`, `.vscode`, `.idea`, `.husky`, `~/.gitconfig`, `~/.bashrc`, `~/.zshrc`, `~/.ssh`, system directories (`/bin`, `/usr`)
+
+### Enforcement
+
+OS-level (Seatbelt on macOS, bubblewrap on Linux). All child processes inherit restrictions.
+
+## Auto-Allow Mode Security Boundaries
+
+### Auto-allows (no prompts)
+
+- Bash commands within sandbox boundaries
+- File writes/deletes inside CWD
+- Network requests to pre-approved domains
+
+### Still prompts
+
+- Remote-modifying commands (`git push`, `gh pr create`, `gh api` POST/DELETE)
+- Writes outside CWD (unless explicitly allowed)
+- Network to unapproved domains
+- Edit/Write/Read tools (governed by their own permission rules)
+
+## Risk Assessment (repo-scoped session)
+
+| Concern | Risk | Notes |
+| --- | --- | --- |
+| Deletes files in repo | Possible | Reversible via git |
+| Modifies files outside repo | Blocked | Sandbox boundary |
+| Pushes to remote | Prompts | Not auto-allowed |
+| Creates/closes PRs or issues | Prompts | Not auto-allowed |
+| Exfiltrates code | Blocked | Network proxy |
+| Modifies git/shell config | Blocked | Protected path |
+| Malicious subprocess escapes | Blocked | OS-enforced |
+
+## Native Sandbox vs Docker
+
+| Feature | Native Sandbox | Docker Container |
+| --- | --- | --- |
+| Setup | Built-in, zero deps (macOS) | Docker daemon + image management |
+| Performance | Near-native | Higher overhead, slower I/O |
+| Filesystem | Selective read/write | All-or-nothing volume mounts |
+| Network | Domain-level filtering | Complete isolation unless ports exposed |
+| Dev workflow | IDE, shell, tools seamless | Must enter container; separate tooling |
+| Isolation strength | OS sandbox primitives | Full kernel-level isolation (stronger) |
+| Escape difficulty | `dangerouslyDisableSandbox` exists | Harder (unless `--privileged`) |
+
+### When native sandbox fits
+
+- Local dev with trusted code
+- CI/CD (fewer dependencies)
+- Performance-sensitive workflows
+- Autonomous Claude with guardrails, not container friction
+
+### When Docker fits better
+
+- Untrusted third-party code
+- Strict compliance requiring full OS isolation
+- Multi-tenant scenarios
+- Complete network lockdown needed
+
+The two approaches are complementary. Some teams run Claude Code with native sandboxing inside a Docker container for defense in depth.

--- a/internals/sandbox-mode-evaluation.md
+++ b/internals/sandbox-mode-evaluation.md
@@ -33,7 +33,7 @@ Opens a menu to choose between auto-allow and regular permissions. Can toggle mi
 ### Filesystem
 
 - Writes confined to CWD and subdirectories by default
-- Reads allowed broadly
+- Reads are unrestricted by default
 - Extra write capability is typically granted through permission allowlist patterns (for example, `permissions.allow` entries) rather than `sandbox.filesystem.*` configuration keys
 
 ### Network
@@ -78,7 +78,7 @@ OS-level (Seatbelt on macOS, bubblewrap on Linux). All child processes inherit r
 | Modifies files outside repo | Blocked | Sandbox boundary |
 | Pushes to remote | Prompts | Not auto-allowed |
 | Creates/closes PRs or issues | Prompts | Not auto-allowed |
-| Exfiltrates code | Mitigated | Unapproved domains are blocked, but approved domains can still be exfiltration paths |
+| Exfiltrates code | Mitigated | Unapproved domains are blocked, but approved domains and tool-use side channels (e.g., data in API call bodies) are not filtered |
 | Modifies git/shell config | Blocked | Protected path |
 | Malicious subprocess escapes | Blocked | OS-enforced |
 
@@ -94,7 +94,7 @@ OS-level (Seatbelt on macOS, bubblewrap on Linux). All child processes inherit r
 | Network | Domain-level filtering | Complete isolation unless ports exposed |
 | Dev workflow | IDE, shell, tools seamless | Must enter container; separate tooling |
 | Isolation strength | OS sandbox primitives | Full kernel-level isolation (stronger) |
-| Escape difficulty | `dangerouslyDisableSandbox` flag (prompts user) | Harder (unless `--privileged`) |
+| Escape difficulty | `dangerouslyDisableSandbox` flag (prompts user in interactive sessions; headless behavior depends on permission mode) | Harder (unless `--privileged`) |
 
 ### When native sandbox fits
 

--- a/internals/sandbox-mode-evaluation.md
+++ b/internals/sandbox-mode-evaluation.md
@@ -78,7 +78,7 @@ OS-level (Seatbelt on macOS, bubblewrap on Linux). All child processes inherit r
 | Modifies files outside repo | Blocked | Sandbox boundary |
 | Pushes to remote | Prompts | Not auto-allowed |
 | Creates/closes PRs or issues | Prompts | Not auto-allowed |
-| Exfiltrates code | Blocked | Network proxy |
+| Exfiltrates code | Mitigated | Unapproved domains are blocked, but approved domains can still be exfiltration paths |
 | Modifies git/shell config | Blocked | Protected path |
 | Malicious subprocess escapes | Blocked | OS-enforced |
 

--- a/internals/sandbox-mode-evaluation.md
+++ b/internals/sandbox-mode-evaluation.md
@@ -1,5 +1,9 @@
 # Claude Code Sandbox Mode Evaluation
 
+How sandbox mode works, what it restricts, and when to use it vs. Docker isolation.
+
+---
+
 ## Enabling Sandbox Mode
 
 ### Via settings.json (persistent, silent)
@@ -25,6 +29,8 @@ Opens a menu to choose between auto-allow and regular permissions. Can toggle mi
 - **Linux/WSL2**: install `bubblewrap` and `socat`
 - **WSL1**: not supported
 
+---
+
 ## What the Sandbox Restricts
 
 ### Filesystem
@@ -47,6 +53,8 @@ Opens a menu to choose between auto-allow and regular permissions. Can toggle mi
 
 OS-level (Seatbelt on macOS, bubblewrap on Linux). All child processes inherit restrictions.
 
+---
+
 ## Auto-Allow Mode Security Boundaries
 
 ### Auto-allows (no prompts)
@@ -60,7 +68,8 @@ OS-level (Seatbelt on macOS, bubblewrap on Linux). All child processes inherit r
 - Remote-modifying commands (`git push`, `gh pr create`, `gh api` POST/DELETE)
 - Writes outside CWD (unless explicitly allowed)
 - Network to unapproved domains
-- Edit/Write/Read tools (governed by their own permission rules)
+
+---
 
 ## Risk Assessment (repo-scoped session)
 
@@ -74,6 +83,8 @@ OS-level (Seatbelt on macOS, bubblewrap on Linux). All child processes inherit r
 | Modifies git/shell config | Blocked | Protected path |
 | Malicious subprocess escapes | Blocked | OS-enforced |
 
+---
+
 ## Native Sandbox vs Docker
 
 | Feature | Native Sandbox | Docker Container |
@@ -84,7 +95,7 @@ OS-level (Seatbelt on macOS, bubblewrap on Linux). All child processes inherit r
 | Network | Domain-level filtering | Complete isolation unless ports exposed |
 | Dev workflow | IDE, shell, tools seamless | Must enter container; separate tooling |
 | Isolation strength | OS sandbox primitives | Full kernel-level isolation (stronger) |
-| Escape difficulty | `dangerouslyDisableSandbox` exists | Harder (unless `--privileged`) |
+| Escape difficulty | `dangerouslyDisableSandbox` flag (prompts user) | Harder (unless `--privileged`) |
 
 ### When native sandbox fits
 

--- a/internals/sandbox-mode-evaluation.md
+++ b/internals/sandbox-mode-evaluation.md
@@ -42,9 +42,11 @@ Opens a menu to choose between auto-allow and regular permissions. Can toggle mi
 - New domains trigger prompts (or deny in stricter permission modes)
 - Domain-level only, no TLS inspection
 
-### Protected paths (never auto-approved)
+### Protected paths (different protection semantics)
 
-`.git`, `.claude`, `.vscode`, `.idea`, `.husky`, `~/.gitconfig`, `~/.bashrc`, `~/.zshrc`, `~/.ssh`, system directories (`/bin`, `/usr`)
+- **Repo metadata/config paths (never auto-approved):** `.git`, `.claude`, `.vscode`, `.idea`, `.husky`
+- **User-home config/credential paths (high-friction; typically prompt/deny):** `~/.gitconfig`, `~/.bashrc`, `~/.zshrc`, `~/.ssh`
+- **System paths (outside normal write scope; prompt/deny):** `/bin`, `/usr`
 
 ### Enforcement
 

--- a/internals/sandbox-mode-evaluation.md
+++ b/internals/sandbox-mode-evaluation.md
@@ -8,9 +8,12 @@ How sandbox mode works, what it restricts, and when to use it vs. Docker isolati
 
 ### Via settings.json (persistent, schema can change)
 
-Use `/sandbox` once, then inspect `~/.claude/settings.json` (or project `.claude/settings.json`) to see the exact keys your installed Claude Code version writes.
+Use `/sandbox` once, then inspect settings at both scopes:
 
-This doc intentionally avoids pinning an unverified `sandbox.enabled`/`sandbox.mode` schema example.
+- `~/.claude/settings.json` (global defaults)
+- `<repo>/.claude/settings.json` (project overrides, when present)
+
+This doc intentionally avoids pinning an unverified `sandbox.enabled`/`sandbox.mode` schema example because key names and structure can vary across Claude Code versions.
 
 ### Via `/sandbox` command (interactive, ad-hoc)
 


### PR DESCRIPTION
## Summary

- Adds `internals/sandbox-mode-evaluation.md` covering sandbox mode enablement, restrictions (filesystem, network, protected paths), auto-allow security boundaries, risk assessment, and native sandbox vs Docker tradeoffs.
- Follows existing internals doc conventions (intro line, section separators, table formatting).

## Related

- #25 - follow-up investigation into sandbox allowlist config for 1Password SSH signing (discovered during this work)

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Spot-check claims against current Claude Code sandbox behavior