### PR TITLE
docs(CLAUDE.md): add interim sandbox workaround for TLS/proxy

### DIFF
--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -124,7 +124,9 @@ Two sandbox restrictions break GitHub operations. Use `dangerouslyDisableSandbox
 - **`gh` CLI commands** (`gh api`, `gh pr`, `gh issue`, `gh run`) - corporate proxy TLS causes `x509: OSStatus -26276`
 - **`git push`, `git fetch`, `git clone`** against `github.com` remotes - sandbox blocks the 1Password SSH agent socket
 
-Do not use `dangerouslyDisableSandbox` for `curl`, arbitrary HTTP calls, or SSH to non-GitHub hosts. Don't retry inside the sandbox first; go straight to `dangerouslyDisableSandbox` for the commands above. Both issues tracked in #25.
+Don't retry inside the sandbox first; go straight to `dangerouslyDisableSandbox` for the commands above. Both issues tracked in #25.
+
+- Do not use `dangerouslyDisableSandbox` for `curl`, arbitrary HTTP calls, or SSH to non-GitHub hosts.
 
 ## External API Calls
 

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -126,7 +126,7 @@ Two sandbox restrictions break GitHub operations. Use `dangerouslyDisableSandbox
 
 Don't retry inside the sandbox first; go straight to `dangerouslyDisableSandbox` for the commands above. Both issues tracked in #25.
 
-- Do not use `dangerouslyDisableSandbox` for `curl`, arbitrary HTTP calls, or SSH to non-GitHub hosts.
+- Do not use `dangerouslyDisableSandbox` for `curl`, arbitrary HTTP calls, or SSH to non-GitHub hosts. If needed, ask for explicit permission first.
 
 ## External API Calls
 

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -117,6 +117,10 @@ On correction (user or self-caught): propose `CLAUDE.md` update **immediately, b
 - **Write/destructive/irreversible: ask first.** `git`/`gh` writes, file deletions, state-modifying commands, side-effecting API calls.
 - Local `CLAUDE.md` may add project-specific permissions or restrictions.
 
+## Sandbox Workaround (interim)
+
+Corporate proxy re-signs HTTPS with a custom CA that the sandbox can't verify, causing `x509: OSStatus -26276` on `gh`/`curl` calls to GitHub. **Use `dangerouslyDisableSandbox: true` on all `gh api`, `gh pr`, `gh issue`, `gh run`, and `curl` calls to external hosts.** Don't retry inside the sandbox first; go straight to `dangerouslyDisableSandbox`. Proper fix tracked in `dgowrie/claude-workflows#25`.
+
 ## External API Calls
 
 - **Probe once, then parallelize.** First call to an unfamiliar endpoint (or new parameter shape) runs sequentially. Only parallelize siblings after that probe succeeds. Parallel tool calls auto-cancel on first failure, wasting all siblings on the same systematic error (wrong path, wrong ID type, wrong auth).

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -119,12 +119,12 @@ On correction (user or self-caught): propose `CLAUDE.md` update **immediately, b
 
 ## Sandbox Workaround (interim - remove when #25 is resolved)
 
-Two sandbox restrictions require `dangerouslyDisableSandbox: true` as a workaround:
+Two sandbox restrictions break GitHub operations. Use `dangerouslyDisableSandbox: true` **only** for:
 
-1. **TLS/proxy:** Corporate proxy re-signs HTTPS with a custom CA the sandbox can't verify, causing `x509: OSStatus -26276`. Affects `gh api`, `gh pr`, `gh issue`, `gh run`, `curl` to external hosts.
-2. **SSH:** Sandbox blocks the 1Password SSH agent socket, breaking `git push`, `git fetch`, `git clone` over SSH.
+- **`gh` CLI commands** (`gh api`, `gh pr`, `gh issue`, `gh run`) - corporate proxy TLS causes `x509: OSStatus -26276`
+- **`git push`, `git fetch`, `git clone`** against `github.com` remotes - sandbox blocks the 1Password SSH agent socket
 
-**Use `dangerouslyDisableSandbox: true` on all commands that hit external hosts or use SSH.** Don't retry inside the sandbox first; go straight to `dangerouslyDisableSandbox`. Both issues tracked in #25.
+Do not use `dangerouslyDisableSandbox` for `curl`, arbitrary HTTP calls, or SSH to non-GitHub hosts. Don't retry inside the sandbox first; go straight to `dangerouslyDisableSandbox` for the commands above. Both issues tracked in #25.
 
 ## External API Calls
 

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -117,9 +117,14 @@ On correction (user or self-caught): propose `CLAUDE.md` update **immediately, b
 - **Write/destructive/irreversible: ask first.** `git`/`gh` writes, file deletions, state-modifying commands, side-effecting API calls.
 - Local `CLAUDE.md` may add project-specific permissions or restrictions.
 
-## Sandbox Workaround (interim)
+## Sandbox Workaround (interim - remove when #25 is resolved)
 
-Corporate proxy re-signs HTTPS with a custom CA that the sandbox can't verify, causing `x509: OSStatus -26276` on `gh`/`curl` calls to GitHub. **Use `dangerouslyDisableSandbox: true` on all `gh api`, `gh pr`, `gh issue`, `gh run`, and `curl` calls to external hosts.** Don't retry inside the sandbox first; go straight to `dangerouslyDisableSandbox`. Proper fix tracked in `dgowrie/claude-workflows#25`.
+Two sandbox restrictions require `dangerouslyDisableSandbox: true` as a workaround:
+
+1. **TLS/proxy:** Corporate proxy re-signs HTTPS with a custom CA the sandbox can't verify, causing `x509: OSStatus -26276`. Affects `gh api`, `gh pr`, `gh issue`, `gh run`, `curl` to external hosts.
+2. **SSH:** Sandbox blocks the 1Password SSH agent socket, breaking `git push`, `git fetch`, `git clone` over SSH.
+
+**Use `dangerouslyDisableSandbox: true` on all commands that hit external hosts or use SSH.** Don't retry inside the sandbox first; go straight to `dangerouslyDisableSandbox`. Both issues tracked in #25.
 
 ## External API Calls
 


### PR DESCRIPTION
## Summary

- Add interim workaround section to CLAUDE.md for two sandbox restrictions:
  1. Corporate proxy TLS issue (`x509: OSStatus -26276`) breaking `gh`/`curl`
  2. 1Password SSH agent socket blocked, breaking `git push`/`fetch`/`clone`
- Documents `dangerouslyDisableSandbox: true` as the interim fix for both

## Cleanup

This section is explicitly interim and should be removed when #25 is resolved. The heading includes a reminder.

## Test plan

- [ ] Verify the workaround section renders correctly in config/CLAUDE.md
- [ ] Confirm the guidance matches what's already live in `~/.claude/CLAUDE.md`