### PR TITLE
fix(skills): simplify setup-cowork wording, remove user-invocable flag

### DIFF
--- a/skills/setup-cowork/SKILL.md
+++ b/skills/setup-cowork/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: setup-cowork
 description: "Guided Cowork setup — install role-matched plugins, connect your tools, try a skill."
-user-invocable: true
 ---
 
 # Setup Cowork
 
-Help the user get Cowork configured for their work. Five user-facing steps — role, plugins, connectors, try a skill, wrap — preceded by a hidden Step 0 (checklist setup) that runs before the first message.
+Help the user get Cowork configured for their work. Five steps — role, plugins, connectors, try a skill, wrap.
 
 ## Step 0 — Checklist
 
@@ -32,7 +31,7 @@ If memory has nothing, ask: "Let's get you set up — takes a few minutes. What 
 
 The role picker tool result will contain their selection. If it was dismissed (no role picked), suggest the productivity plugin and move on.
 
-**Always** check for already-installed plugins before doing anything else — this is not optional. Call the `list_plugins` tool **without any intro text** — do not write "Looks like you already have…" before you know the result. The tool renders the installed plugins as a widget on its own; let it speak for itself. After it returns, react to what actually came back: if plugins appeared, acknowledge them below the widget ("Those are already on your account — here's what else fits your role."); if it's empty, just say "No plugins yet — let's fix that." Never write text that presumes a non-empty result before the tool runs. Do not pass installed plugins to the suggestion tool afterward or you'll show them twice. Admin-provisioned plugins will appear in this list automatically; never skip the call. Then search for role-matched plugins to recommend — but only show the recommendations widget if there is at least one non-installed match.
+**Always** check for already-installed plugins before doing anything else — this is not optional. Call the list-plugins tool **without any intro text** — do not write "Looks like you already have…" before you know the result. The tool renders the installed plugins as a widget on its own; let it speak for itself. After it returns, react to what actually came back: if plugins appeared, acknowledge them below the widget ("Those are already on your account — here's what else fits your role."); if it's empty, just say "No plugins yet — let's fix that." Never write text that presumes a non-empty result before the tool runs. Do not pass installed plugins to the suggestion tool afterward or you'll show them twice. Admin-provisioned plugins will appear in this list automatically; never skip the call. Then, regardless of what's installed, still recommend new role-matched plugins below in a separate widget.
 
 Search the plugin marketplace for their role. **Exclude anything already installed** — the installed-plugins widget above already covers those, so the recommendations widget must only contain plugins the user does not yet have. Never show the same plugin in both widgets. **Organization plugins always come first.** If the user's org has published its own plugins, those are the recommendation — they're built for this company's actual tools, data, and workflows, and someone internal decided they matter. An org-built plugin that's even loosely relevant to the role outranks any generic marketplace plugin, full stop. Lead with org plugins, and only reach for generic ones to fill empty slots when the org catalog has nothing close. Never bury an org plugin under a generic one. Hold on to the result: you'll need each plugin's `skills` and `mcpServerNames` later.
 
@@ -52,7 +51,7 @@ Below the suggestions, explain what they're looking at before moving on: "Click 
 
 ## Step 4 — Try a skill
 
-If they say yes, call list_skills with the deduplicated skill names from **all plugins currently in play** (any relevant already-installed plugins plus any newly added plugins from this setup flow), and use a context_label like "Available skills" so they get clickable Try-it cards. Introduce the card in one line so it doesn't land cold: "Here are some skills you can try now — click any of these to run it." End your turn.
+If they say yes, call list_skills with the plugin's skill names and a context_label like "[Plugin] skills" so they get clickable Try-it cards. Introduce the card in one line so it doesn't land cold: "Here's what [Plugin] adds — click any of these to run it now." End your turn.
 
 When they click one (you'll see a `/name` message), help them with it. Keep it brief; you're still inside setup. When it finishes, bring it back: "Nice — that's how skills work."
 


### PR DESCRIPTION
## Context

**setup-cowork** is a guided onboarding wizard for Cowork. It walks new users through five steps: identify their role, install role-matched plugins (org-published first), connect data sources (Slack, email, docs), try a skill, and wrap up. The core value prop it communicates: Cowork autonomously handles tasks using `/skill` commands, powered by plugins and backed by real tool connections. The setup skill gets users from zero to productive with the right plugins and connectors for their job.

## Changes

Cleanup pass to align the skill spec with how it's actually used:

- Remove `user-invocable: true` from frontmatter (skill is agent-triggered, not user-invoked)
- Fix tool name from `list_plugins` to `list-plugins`
- Simplify step descriptions and tighten plugin recommendation logic
- Always show role-matched plugin recommendations regardless of what's already installed
- Scope Step 4 skill listing to a single plugin instead of deduplicating across all

## Out of scope

- **Voice and tone capture**: the skill currently does not capture how the user writes or communicates. A followup should consider adding a step (or separate skill) that establishes the user's voice and tone so the agent can write as they would.

## Test plan

- [ ] Verify SKILL.md parses correctly without user-invocable flag
- [ ] Confirm wording changes are consistent with the rest of the skill flow