### PR TITLE
chore: gitignore slack-plugin-release-post skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Skills with internal/private references
+skills/slack-plugin-release-post/


### PR DESCRIPTION
## Summary
- Adds `.gitignore` to exclude `skills/slack-plugin-release-post/` from the public repo
- Skill contains Grafana-internal references (repo URLs, Slack channel IDs, custom workspace emoji) that should not be published

## Test plan
- [ ] Verify `git status` no longer shows `skills/slack-plugin-release-post/` as untracked