### PR TITLE
feat: add global rules for memory audit, hygiene, and self-correction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,15 @@ This repo contains reference material, learnings, and tools for working with Cla
 - `workflows/` — patterns and practices for working effectively with Claude Code
 - `explorations/` — session notes and findings from investigating Claude Code behavior
 - `skills/` — skill drafts and development (before deploying to `~/.claude/skills/`)
+- `config/` — global `CLAUDE.md` and `rules/`, symlinked into `~/.claude/`
+
+## Adding a new rule
+
+When adding a rule to `config/rules/`:
+
+1. Create `config/rules/<name>.md` (plain markdown, optional `paths` frontmatter for scoping)
+2. Symlink into `~/.claude/rules/`: `ln -s ~/dev/claude-workflows/config/rules/<name>.md ~/.claude/rules/<name>.md`
+3. Add an entry to the Rules section in `README.md`
 
 ## Adding a new skill
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Claude Code's built-in persistence (memory, plans) is useful but fragile: memori
 ## Structure
 
 ```
+config/        Global CLAUDE.md and rules, symlinked into ~/.claude/
 internals/     How Claude Code works under the hood
 workflows/     Patterns and practices for effective use
 explorations/  Session notes and behavioral findings
@@ -51,6 +52,18 @@ Changes to a skill file in the repo are immediately live — no copy or sync ste
 - [`/tdd`](skills/tdd/SKILL.md) — test-driven development with red-green-refactor loop and reference guides
 - [`/review-thorough`](skills/review-thorough/SKILL.md) — wraps built-in `/review` and additionally evaluates bot reviews including resolved threads
 - [`/security-audit`](skills/security-audit/SKILL.md) — three-phase source-code vulnerability scan (dep audit, parallelized source review, verification + false-positive triage) with GitHub issue tracking
+
+### Rules
+
+Rules in `config/rules/` are symlinked into `~/.claude/rules/`, making them globally active across all projects. Like skills, edits in the repo are immediately live.
+
+```
+~/.claude/rules/memory-session-exit.md -> ~/dev/claude-workflows/config/rules/memory-session-exit.md
+```
+
+- [Memory Session Exit](config/rules/memory-session-exit.md) — audit and update project memories before ending any substantive session
+- [Memory Hygiene](config/rules/memory-hygiene.md) — guidelines for memory file size, deduplication, and lifecycle
+- [Self-Correction Loop](config/rules/self-correction-loop.md) — on correction, propose a CLAUDE.md or rule update before continuing
 
 ## Improvements to consider
 

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -83,23 +83,6 @@ For each issue: describe with file/line references, present 2-3 options (includi
 - Future work: `// TODO: description (#issue)`. Always greppable `TODO` prefix.
 - **Markdown tables:** spaces on both sides of every `|` separator (markdownlint MD060).
 
-## Self-Correction Loop
-
-On correction (user or self-caught): propose `CLAUDE.md` update **immediately, before continuing the task**.
-
-- **Trigger**: user correction; or self-correction worth generalizing
-- **Scope**: substantive mistakes, violated preferences, meaningful tone/style findings
-- **Target**: global `CLAUDE.md` if broadly applicable; most local `CLAUDE.md` otherwise
-- **Process**: (1) stop task (2) propose rule + reasoning (3) apply on confirmation (4) resume
-
-## Memory Hygiene
-
-- **Index descriptions: specific and filterable** - name feature, issue number, or domain.
-- **Individual files under 1KB.** Over 2KB belongs in a plan, repo doc, or code comment.
-- **Check for existing memory before writing new.** Fewer well-scoped > many granular.
-- **Delete shipped/resolved/obsolete memories.** Remove file and MEMORY.md entry.
-- **Project context -> memory. Global rules -> CLAUDE.md.** Promote feedback memories useful across 2+ sessions.
-
 ## Tool Permissions and Sandbox
 
 - **Read-only: never prompt.** `git diff`, `gh pr view`, `grep`, `ls`, `cat`, version checks, etc.

--- a/config/rules/memory-hygiene.md
+++ b/config/rules/memory-hygiene.md
@@ -4,4 +4,4 @@
 - **Individual files under 1KB.** Over 2KB belongs in a plan, repo doc, or code comment.
 - **Check for existing memory before writing new.** Fewer well-scoped > many granular.
 - **Delete shipped/resolved/obsolete memories.** Remove file and MEMORY.md entry.
-- **Project context -> memory. Global rules -> CLAUDE.md.** Promote feedback memories useful across 2+ sessions.
+- **Project context -> memory. Global rules -> CLAUDE.md or `~/.claude/rules/`.** Promote feedback memories useful across 2+ sessions.

--- a/config/rules/memory-hygiene.md
+++ b/config/rules/memory-hygiene.md
@@ -1,0 +1,7 @@
+# Memory Hygiene
+
+- **Index descriptions: specific and filterable** - name feature, issue number, or domain.
+- **Individual files under 1KB.** Over 2KB belongs in a plan, repo doc, or code comment.
+- **Check for existing memory before writing new.** Fewer well-scoped > many granular.
+- **Delete shipped/resolved/obsolete memories.** Remove file and MEMORY.md entry.
+- **Project context -> memory. Global rules -> CLAUDE.md.** Promote feedback memories useful across 2+ sessions.

--- a/config/rules/memory-session-exit.md
+++ b/config/rules/memory-session-exit.md
@@ -1,0 +1,41 @@
+# Session Exit: Memory Audit
+
+Before ending any session where substantive work occurred, audit the project's memory files. Skip for trivial sessions (quick questions, no code changes, no decisions made).
+
+## Trigger
+
+When wrapping up - recognizable by: user says "done"/"thanks"/"that's it"/similar, or the task is complete and there's nothing left to do.
+
+## Audit Steps
+
+1. **Identify relevant memories.** Read `MEMORY.md` index; open any memory file whose description overlaps with this session's work.
+2. **Check for staleness.** Compare each relevant memory's content against what actually happened this session. A memory is stale if:
+   - It describes state that changed (scope shifted, question resolved, approach abandoned)
+   - It references artifacts that were renamed, moved, or deleted
+   - It contains "TODO" or "open question" items that were resolved
+3. **Check for consolidation opportunities.** Flag memories that overlap significantly or could merge into one.
+4. **Check for obsolete memories.** Flag memories for work that shipped, was abandoned, or is no longer relevant.
+
+## Actions
+
+**Non-destructive (update in place, no confirmation needed):**
+- Update stale facts, resolved questions, corrected scope
+- Fix broken references (renamed files, moved paths)
+- Update MEMORY.md index descriptions to match revised content
+
+**Destructive (prompt user before proceeding):**
+- Deleting memory files (obsolete, shipped, abandoned)
+- Merging/consolidating multiple files into one (deletes originals)
+
+## Output
+
+End with a compact summary:
+
+```
+Memory audit:
+- Updated N: name1 (brief reason), name2 (brief reason)
+- Removed N: name1 (brief reason), name2 (brief reason)
+- No changes needed / Skipped (trivial session)
+```
+
+No other commentary. If nothing changed, say so in one line and move on.

--- a/config/rules/self-correction-loop.md
+++ b/config/rules/self-correction-loop.md
@@ -1,0 +1,8 @@
+# Self-Correction Loop
+
+On correction (user or self-caught): propose `CLAUDE.md` or rule file update **immediately, before continuing the task**.
+
+- **Trigger**: user correction; or self-correction worth generalizing
+- **Scope**: substantive mistakes, violated preferences, meaningful tone/style findings
+- **Target**: global `~/.claude/CLAUDE.md` if broadly applicable; most local `CLAUDE.md` otherwise. Discrete concerns get their own rule file in `~/.claude/rules/`.
+- **Process**: (1) stop task (2) propose rule + reasoning (3) apply on confirmation (4) resume

--- a/config/rules/self-correction-loop.md
+++ b/config/rules/self-correction-loop.md
@@ -4,5 +4,5 @@ On correction (user or self-caught): propose `CLAUDE.md` or rule file update **i
 
 - **Trigger**: user correction; or self-correction worth generalizing
 - **Scope**: substantive mistakes, violated preferences, meaningful tone/style findings
-- **Target**: global `~/.claude/CLAUDE.md` if broadly applicable; most local `CLAUDE.md` otherwise. Discrete concerns get their own rule file in `~/.claude/rules/`.
+- **Target**: global `~/.claude/CLAUDE.md` if broadly applicable; the most local `CLAUDE.md` otherwise. Discrete concerns get their own rule file in `~/.claude/rules/`.
 - **Process**: (1) stop task (2) propose rule + reasoning (3) apply on confirmation (4) resume


### PR DESCRIPTION
## Summary

- Add `config/rules/` directory with three global rule files, symlinked into `~/.claude/rules/` following the same convention as skills
- **memory-session-exit**: audits and updates project memories before ending any substantive session; prompts for destructive actions (deletions, consolidations), auto-confirms simple updates, outputs a compact change summary
- **memory-hygiene**: extracted from `CLAUDE.md` - guidelines for memory file size, deduplication, and lifecycle
- **self-correction-loop**: extracted from `CLAUDE.md` - on correction, propose a rule or CLAUDE.md update before continuing (updated to reference `~/.claude/rules/` as a target)
- Update `CLAUDE.md` (project) with "Adding a new rule" instructions
- Update `README.md` with Rules section and `config/` in directory structure

## Motivation

Memories were going stale across sessions without being noticed or updated. The session-exit rule ensures Claude audits relevant memories before wrapping up. Extracting Memory Hygiene and Self-Correction Loop into discrete rule files starts the modularization of CLAUDE.md into single-concern rules.

## Test plan

- [ ] Verify symlinks resolve: `ls -la ~/.claude/rules/`
- [ ] Start a new session, confirm rules appear in system context
- [ ] End a substantive session, confirm memory audit triggers
- [ ] Confirm destructive actions prompt before proceeding