### PR TITLE
feat(config): enforce no-em-dash rule with PreToolUse hook

### DIFF
--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -8,7 +8,7 @@ Personal defaults applied across all sessions and projects. Local `CLAUDE.md` fi
 - No flattery or compliments unless explicitly asked for judgment.
 - When uncertain about intent or direction, ask. Keep asking until ambiguity is fully resolved.
 - Don't speculate as if stating fact. When uncertain, say so and frame hypotheses as hypotheses.
-- **No em dashes (—, U+2014) anywhere, ever.** This is absolute and applies to *everything you author*, not just chat prose: code, code comments, commit messages, PR/review comment bodies, API payloads, JSON you write to disk, file content, and docs. Use a hyphen, comma, semicolon, or parentheses instead. A PreToolUse hook blocks em-dashes in Write/Edit content as a backstop, but the prohibition holds even where the hook can't reach (e.g. inline Bash).
+- **No em dashes (U+2014) anywhere, ever.** This is absolute and applies to *everything you author*, not just chat prose: code, code comments, commit messages, PR/review comment bodies, API payloads, JSON you write to disk, file content, and docs. Use a hyphen, comma, semicolon, or parentheses instead. A PreToolUse hook blocks the em dash (U+2014) along with the en dash (U+2013) and horizontal bar (U+2015) in Write/Edit content as a backstop, but the prohibition holds even where the hook can't reach (e.g. inline Bash).
 
 ## Agentic Workflow
 

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -8,7 +8,7 @@ Personal defaults applied across all sessions and projects. Local `CLAUDE.md` fi
 - No flattery or compliments unless explicitly asked for judgment.
 - When uncertain about intent or direction, ask. Keep asking until ambiguity is fully resolved.
 - Don't speculate as if stating fact. When uncertain, say so and frame hypotheses as hypotheses.
-- **No em dashes anywhere.** Use hyphens, commas, or semicolons.
+- **No em dashes (—, U+2014) anywhere, ever.** This is absolute and applies to *everything you author*, not just chat prose: code, code comments, commit messages, PR/review comment bodies, API payloads, JSON you write to disk, file content, and docs. Use a hyphen, comma, semicolon, or parentheses instead. A PreToolUse hook blocks em-dashes in Write/Edit content as a backstop, but the prohibition holds even where the hook can't reach (e.g. inline Bash).
 
 ## Agentic Workflow
 

--- a/config/hooks/block-em-dash.sh
+++ b/config/hooks/block-em-dash.sh
@@ -4,6 +4,14 @@
 # Exit 2 = block the tool call and feed stderr back to Claude.
 set -euo pipefail
 
+# Hard dependency: without jq we cannot read the tool input. Under `set -e` a
+# missing jq would abort with a generic "command not found" and an ambiguous
+# exit code; block explicitly with an actionable reason instead.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Blocked: block-em-dash hook requires 'jq', which was not found on PATH. Install jq, then retry." >&2
+  exit 2
+fi
+
 input=$(cat)
 
 # Pull the author-supplied text out of whichever tool fired:

--- a/config/hooks/block-em-dash.sh
+++ b/config/hooks/block-em-dash.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block em-dash (—, U+2014) in any content Claude authors via
+# Write/Edit. Enforces the global CLAUDE.md rule "No em dashes anywhere, ever".
+# Exit 2 = block the tool call and feed stderr back to Claude.
+set -euo pipefail
+
+input=$(cat)
+
+# Pull the author-supplied text out of whichever tool fired:
+#   Write -> .tool_input.content
+#   Edit  -> .tool_input.new_string
+# (NotebookEdit uses .tool_input.new_source if this matcher is ever widened.)
+content=$(printf '%s' "$input" | jq -r '
+  [ .tool_input.content, .tool_input.new_string, .tool_input.new_source ]
+  | map(select(. != null))
+  | join("\n")
+')
+
+# U+2014 EM DASH. Also catch the rarer U+2015 HORIZONTAL BAR and U+2013 EN DASH,
+# which are the same misuse class the rule is guarding against.
+if printf '%s' "$content" | grep -q '[—―–]'; then
+  echo "Blocked: em-dash/en-dash forbidden anywhere (global CLAUDE.md: \"No em dashes anywhere, ever\"). Replace —/–/― with a hyphen, comma, semicolon, or parentheses, then retry." >&2
+  exit 2
+fi
+
+exit 0

--- a/config/hooks/block-em-dash.sh
+++ b/config/hooks/block-em-dash.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# PreToolUse hook: block em-dash (—, U+2014) in any content Claude authors via
+# PreToolUse hook: block the em dash (U+2014) in any content Claude authors via
 # Write/Edit. Enforces the global CLAUDE.md rule "No em dashes anywhere, ever".
 # Exit 2 = block the tool call and feed stderr back to Claude.
 set -euo pipefail
@@ -16,10 +16,14 @@ content=$(printf '%s' "$input" | jq -r '
   | join("\n")
 ')
 
-# U+2014 EM DASH. Also catch the rarer U+2015 HORIZONTAL BAR and U+2013 EN DASH,
-# which are the same misuse class the rule is guarding against.
-if printf '%s' "$content" | grep -q '[—―–]'; then
-  echo "Blocked: em-dash/en-dash forbidden anywhere (global CLAUDE.md: \"No em dashes anywhere, ever\"). Replace —/–/― with a hyphen, comma, semicolon, or parentheses, then retry." >&2
+# Match the UTF-8 byte sequences for U+2013 EN DASH (e2 80 93), U+2014 EM DASH
+# (e2 80 94), and U+2015 HORIZONTAL BAR (e2 80 95) - the same misuse class the
+# rule guards against. Matching bytes under LC_ALL=C is locale-independent (a C
+# locale would otherwise match the pattern's individual bytes and false-positive
+# on other non-ASCII content) and keeps this script free of the characters it
+# forbids, so it no longer self-blocks Write/Edit.
+if printf '%s' "$content" | LC_ALL=C grep -q $'\xe2\x80[\x93\x94\x95]'; then
+  echo "Blocked: em/en dash (U+2014, U+2013, U+2015) forbidden anywhere (global CLAUDE.md: \"No em dashes anywhere, ever\"). Replace with a hyphen, comma, semicolon, or parentheses, then retry." >&2
   exit 2
 fi
 


### PR DESCRIPTION
## What

Strengthens the global "no em dashes" rule and adds a PreToolUse hook that enforces it.

## How we found the gap

While drafting PR review comments on another repo, Claude wrote em-dashes into the review comment bodies. The global `CLAUDE.md` already said "No em dashes anywhere," but the wording was loose enough to be read as applying to chat prose only, not to content authored into files, commit messages, and API payloads. Prose guidance alone did not prevent the violation.

## Changes

- **`config/CLAUDE.md`**: broadened the rule so it is explicit and absolute. It now names the surfaces it covers (code, code comments, commit messages, PR/review comment bodies, API payloads, JSON written to disk, file content, docs) and points at the hook as a backstop.
- **`config/hooks/block-em-dash.sh`** (new): a PreToolUse hook. On `Write`/`Edit` it reads the authored text (`.tool_input.content` / `.new_string` / `.new_source`) and exits 2 (blocking the call, feeding the reason back) if it contains `U+2014` (em dash), `U+2013` (en dash), or `U+2015` (horizontal bar). Symlinked into `~/.claude/hooks/` following the same edit-in-repo-symlink-into-home pattern used for skills and rules.

## Rationale

The harness executes hooks, not the model, so a hook is the only thing that can deterministically stop authored content from carrying an em-dash. The rule text change addresses the "why did I think it was OK" part (scope ambiguity); the hook addresses the "make it impossible" part.

The hook is scoped to `Write`/`Edit` because that is the channel the original mistake actually went through (the review bodies were written to a JSON payload file via `Write`). Inline `Bash` command strings are intentionally not scanned, to avoid false-positives on commands that legitimately read or grep files containing em-dashes; the prose rule covers that residual surface.

## Verification

- Hook unit behavior (piped sample tool-input JSON): blocks em-dash and en-dash content with exit 2; passes hyphen/comma/semicolon content with exit 0.
- `settings.json`: validated as JSON after wiring.
- Live, in-session: a `Write` containing an em-dash was blocked by the hook; a clean `Write` succeeded.
- Post-refactor regression: after moving the script into the repo and symlinking it back, a live `Write` with an em-dash was still blocked through the symlink.

## Not in this PR (machine-local)

`~/.claude/settings.json` is a real, untracked, per-machine file that this repo does not version, so the hook wiring is not committed here. It is already applied locally as:

```json
"hooks": {
  "PreToolUse": [
    { "matcher": "Write|Edit",
      "hooks": [ { "type": "command", "command": "/Users/dggraf/.claude/hooks/block-em-dash.sh" } ] }
  ]
}
```

A fresh machine needs this block added to `~/.claude/settings.json` for the hook to fire.

## Known caveat

The script contains the literal em/en-dash characters in its match pattern, so it cannot be edited via Claude's own `Write`/`Edit` tools (it self-blocks). Edit it directly in an editor or via Bash.
