### PR TITLE
fix(skills): stop perpetual setup-cowork working-tree diff

### DIFF
--- a/skills/setup-cowork/SKILL.md
+++ b/skills/setup-cowork/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: setup-cowork
+name: "setup-cowork"
 description: "Guided Cowork setup — install role-matched plugins, connect your tools, try a skill."
 ---
 


### PR DESCRIPTION
## What

Commits `name: "setup-cowork"` (quoted) in `skills/setup-cowork/SKILL.md` so the file stops showing as a perpetual unstaged change in fresh checkouts.

## Root cause

The diff (`name: setup-cowork` -> `name: "setup-cowork"`) was not git corruption or our sync script. **Cowork (local-agent-mode) re-serializes its own onboarding skill** with a YAML dumper that double-quotes scalars, and `setup-cowork` is symlinked from the Cowork skills dir through `~/.claude/skills` into this repo, so Cowork's rewrite lands in the working tree.

Evidence:

- The change is surgical (only the `name` line; the already-quoted `description` is untouched) - the signature of a YAML load-then-dump.
- The file was written at 13:33:56 with **no Claude Code job running**; a Cowork built-in (`schedule/SKILL.md`) was written the same second.
- Of Cowork's six built-in skills, only the one it re-saved (`schedule`) is quoted; the rest are not. `setup-cowork` is the only repo skill Cowork actively loads/re-saves.
- `sync-skills.sh` provably never edits content (only `cp`/`ln`/`rm`); its WatchPaths trigger just makes it run in the same second as the write.

## Fix

Make the repo a fixed point of Cowork's serializer. The committed blob is byte-identical to what Cowork writes, so subsequent rewrites produce zero diff - across every clone and worktree, no per-checkout config needed.

A YAML comment explaining this was deliberately **not** added: Cowork's dump would strip it and reintroduce a diff. Rationale lives in the commit message instead.

## Scope / not in this PR

Two unrelated loose ends the investigation surfaced (flagged, not fixed here):

- `sync-skills.sh` logs spurious "ACTION NEEDED: commit <skill>" for `.gitignore`d skills (e.g. `slack-plugin-release-post`), because `git ls-files --error-unmatch` is also false for ignored files.
- `skills/AFK/` is an untracked real dir (not ignored, not committed).