### PR TITLE
[NEEDS REVIEW] feat(skills): add writing-voice step to setup-cowork flow (unclear intent)

### DIFF
--- a/skills/setup-cowork/SKILL.md
+++ b/skills/setup-cowork/SKILL.md
@@ -5,7 +5,7 @@ description: "Guided Cowork setup — install role-matched plugins, connect your
 
 # Setup Cowork
 
-Help the user get Cowork configured for their work. Five steps — role, plugins, connectors, try a skill, wrap.
+Help the user get Cowork configured for their work. Six steps — role, plugins, connectors, try a skill, writing voice, wrap.
 
 ## Step 0 — Checklist
 
@@ -15,17 +15,18 @@ Before your first user-facing message, create a TODO list with these items so th
 2. Suggest plugins
 3. Suggest connectors
 4. Try a skill
-5. Wrap up
+5. Set up writing voice
+6. Wrap up
 
-Mark each one complete as you finish it. Keep it to these five — don't add sub-items.
+Mark each one complete as you finish it. Keep it to these six — don't add sub-items.
 
 ## Step 1 — Role
 
 Your initial message should frame what Cowork is: it autonomously handles tasks like reading your email, searching your docs, drafting reports, etc. Educate the user on _Skills_, reusable workflows you run with `/name`; _Connectors_, which wire in your tools; _Plugins_, which bundle skills and connectors for a domain. Two or three sentences. Hit the beats: multi-step and autonomous, uses your real tools, skills/plugins/connectors defined.
 
-**Check memory first.** If your memory already records the user's role or job function, don't ask — state it back: "Looks like you do [role] work — I'll set things up for that." Then skip straight to Step 2.
+**Check the system context first.** If the system prompt includes a line like "The user's role from their account profile is: [role]", use that role directly — weave it into your framing ("Since you're in [role], I'll set things up for that.") and skip the role-picker tool entirely.
 
-If memory has nothing, ask: "Let's get you set up — takes a few minutes. What kind of work do you do?" Then call the tool to show the onboarding role picker, which displays roles for the user to click. Do not list the roles yourself.
+If the system context has no role, end the framing with "Let's get you set up — takes a few minutes." then call the role-picker tool. Do not ask the question in text — the tool's chip panel asks for them. Do not list the roles yourself.
 
 ## Step 2 — Suggest plugins
 
@@ -51,15 +52,39 @@ Below the suggestions, explain what they're looking at before moving on: "Click 
 
 ## Step 4 — Try a skill
 
-If they say yes, call list_skills with the plugin's skill names and a context_label like "[Plugin] skills" so they get clickable Try-it cards. Introduce the card in one line so it doesn't land cold: "Here's what [Plugin] adds — click any of these to run it now." End your turn.
+If they say yes, call list_skills with the plugin's skill names and a context_label like "[Plugin] skills" so they get clickable Try-it cards. Introduce the card in one line so it doesn't land cold: "Here's what [Plugin] adds — click any of these to run it now." End your turn. These cards are [Plugin]'s skills only, not the account's skills — when a later step needs to know what's on the user's account (Step 5 does), the answer comes from the skills list in your system context, never from this card.
 
 When they click one (you'll see a `/name` message), help them with it. Keep it brief; you're still inside setup. When it finishes, bring it back: "Nice — that's how skills work."
 
 If they wave it off at either point, that's fine — go to Step 5.
 
-## Step 5 — Wrap
+## Step 5 — Writing voice
+
+Everything so far taught Cowork about the user's *tools*. This step teaches it about the *user*. This matters because so much of what Cowork produces is prose the user will send under their own name.
+
+**First, settle which opener you're writing — the skills list in your system context decides.** That list is the account's full skills list; any skill cards you showed at Step 4 covered one plugin and can't answer this. If `my-writing-style` is there (the saved profile — not `setup-writing-style`, the flow that creates it) — or the user says they've already set one up — your whole message is one line ("You've already got a voice profile, so anything I draft for you will use it") and you go to Step 6. Only if it's absent do you offer setup. Re-running the flow on someone who's already done it wastes their time and risks overwriting a profile they've tuned. If they *want* to update or redo it, that counts as a yes — invoke the skill the same way.
+
+If the user says they already have one, that settles it — a profile saved recently won't show in your skills list until their next session, so their word beats the list. Never tell a user they don't have a profile on the strength of a widget result; the widgets in this flow are plugin-filtered, and silence from one means nothing. Skipping a redundant offer costs a sentence; overwriting a tuned profile costs the user their work.
+
+If `setup-writing-style` itself isn't available in this session, skip the offer entirely: mark this TODO done and go to Step 6 — the wrap's closing clause covers it.
+
+Otherwise, offer it. Make the case in two or three sentences of prose — these are the beats to hit, not a list to reproduce — then ask. Don't just launch into it:
+
+- **What it does:** reads writing they've already sent, learns how they write, and saves it so future drafts sound like them instead of like Claude.
+- **What it costs:** about two minutes.
+- **What it protects:** only writing they authored, and nothing saves without their review. (One clause — the skill itself walks through consent in detail once they say yes.)
+
+Phrase the ask so passing is obviously fine — "Want to do that now, or skip it?" A user who feels cornered into a two-minute detour at the end of setup will just abandon the whole thing.
+
+**If they say yes:** invoke the `setup-writing-style` skill (via the Skill tool — don't improvise its flow from memory) and let it run end to end. Don't paraphrase its steps, re-explain consent, or interleave your own commentary — it opens with its own framing, and a second voice narrating over it is confusing. Cowork setup is paused, not over. The voice flow counts as finished when one of three things happens: the save tool reports success; the user confirms the profile is saved (when saving happens via a Save skill button, you can't see the click and the new skill won't appear in your skills list until their next session — the flow already has you ask them to click it, so their answer is your signal; don't ask twice); or they ask to skip or move on to something else. Only then mark this TODO done and move to Step 6 — invoking the skill starts this step; it doesn't complete it.
+
+**If they say no or defer:** mark the TODO done and tell them they can always create their voice profile later by simply asking — e.g. "No problem. Whenever you want drafts to sound like you, just ask me to learn your writing voice." Then Step 6. Don't sell it twice.
+
+## Step 6 — Wrap
 
 Close short: "You're set. Start a new task from the sidebar anytime, or type `/` to see your skills."
+
+If they don't have a voice profile by the wrap, add one clause and no more: "…and whenever you want drafts to sound like you, just ask me to learn your writing voice."
 
 ## Ground rules
 
@@ -67,4 +92,4 @@ Close short: "You're set. Start a new task from the sidebar anytime, or type `/`
 - Skips are fine. If they pass on a step, mark its TODO done and move on.
 - Keep each message short. Two or three sentences plus the widget, not a wall.
 - Never write text that presumes a tool result before the tool runs. Don't say "you already have…" or "you're connected to…" above a widget — call the tool first, then react to what came back below it. The widget shows the data; your sentence reacts to it.
-- The user trying a skill mid-flow is expected. Help with it, then return to where you left off. Don't let a skill invocation end the setup.
+- The user trying a skill mid-flow is expected. Help with it, then return to where you left off. Don't let a skill invocation end the setup. This applies to Step 5 too: `setup-writing-style` is a long flow, and when it ends — however it ends — the user still needs the Step 6 wrap.


### PR DESCRIPTION
## What

Adds a new **Step 5 — Writing voice** to the `setup-cowork` guided flow:

- Offers to run `setup-writing-style`, with a guard against re-running / overwriting an existing `my-writing-style` profile.
- Renumbers the old wrap to **Step 6** and adds a fallback clause to the wrap when no voice profile exists.
- Switches Step 1 role detection from **memory** to the **system-context role line**.
- Clarifies the distinction between plugin skill cards (Step 4) and the account's full skills list.

## ⚠️ Unclear intent / history

This change was discovered **uncommitted in the working tree** on an unrelated branch (`chore/pr-reply-no-affirmation`). Tracing it back:

- No branch, worktree, git stash, memory file, or prior/open PR aligns with it.
- File mtime (Jul 16 09:43) matches other untracked skill drafts, suggesting a single recent session.
- **The author does not recall intending this change.**

Branched and opened for review specifically so the work isn't lost and a reviewer can confirm whether this flow change is actually wanted before it merges. If `setup-writing-style` / `my-writing-style` don't exist as referenced, this should not merge as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)