### PR TITLE
docs(claude): drop affirmation prefixes in PR review replies

### DIFF
--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -133,7 +133,7 @@ After pushing to any PR (including drafts), run both concurrently:
 ## PR Review Conventions
 
 **Addressing feedback** (human and bot):
-- Accepted: reply `:zap: <commit hash>`, minimal commentary.
+- Accepted: reply `:zap: <commit hash>` plus a brief change/rationale summary. No affirmation prefixes ("good catch", "fair point", "great point", etc.); state what changed and why, nothing else.
 - Rejected: reply `:thought_balloon: <brief rationale>`.
 - Batch trivial fixes; non-trivial gets its own commit.
 - **Only resolve threads we authored.** Reviewer threads stay open so reviewers can see what was flagged and weigh in. For our threads: resolve after reply is published (if staged as pending, wait until review is submitted).


### PR DESCRIPTION
## What

Tightens the **Addressing feedback → Accepted** convention in `config/CLAUDE.md`:

- Before: `:zap: <commit hash>`, minimal commentary.
- After: `:zap: <commit hash>` plus a brief change/rationale summary, and **no affirmation prefixes** ("good catch", "fair point", "great point", etc.) — state what changed and why, nothing else.

## Why

`config/CLAUDE.md` is symlinked into `~/.claude/CLAUDE.md`, so this refinement propagates to the live global instructions once merged. Single-line docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)