### PR TITLE
fix(sync): skip commit reminders for git-ignored skills

### DIFF
--- a/workflows/sync/sync-skills.sh
+++ b/workflows/sync/sync-skills.sh
@@ -56,7 +56,7 @@ if [[ -d "$COWORK" ]]; then
 
     # Ensure canonical symlink exists (repo -> canonical)
     if [[ ! -L "$CANONICAL/$skill_name" ]]; then
-      [[ -d "$CANONICAL/$skill_name" ]] && rm -rf "$CANONICAL/$skill_name"
+      [[ -d "$CANONICAL/$skill_name" ]] && rm -rf "${CANONICAL:?}/${skill_name:?}"
       ln -s "$REPO/$skill_name" "$CANONICAL/$skill_name"
       log "Linked repo/$skill_name -> canonical"
     fi

--- a/workflows/sync/sync-skills.sh
+++ b/workflows/sync/sync-skills.sh
@@ -138,6 +138,14 @@ fi
 for repo_skill in "$REPO"/*/; do
   [[ ! -d "$repo_skill" ]] && continue
   skill_name=$(basename "$repo_skill")
+  # Skip skills deliberately kept out of git (matched by .gitignore or
+  # .git/info/exclude). git check-ignore is authoritative here: it honors the
+  # exact ignore rules that keep these dirs out of `git status`, so one source
+  # of truth silences the reminder too - no separate skip-list to drift or,
+  # since this repo is public, to leak the intentionally-uncommitted names.
+  if git -C "$REPO/.." check-ignore -q "skills/$skill_name"; then
+    continue
+  fi
   # Check if tracked by git
   if ! git -C "$REPO/.." ls-files --error-unmatch "skills/$skill_name/SKILL.md" >/dev/null 2>&1; then
     log "ACTION NEEDED: '$skill_name' imported to repo but not yet committed - run: cd ~/dev/claude-workflows && git add skills/$skill_name && git commit"


### PR DESCRIPTION
## Problem

`sync-skills.sh` logs an `ACTION NEEDED: commit <skill>` reminder for any repo skill whose `SKILL.md` isn't git-tracked. Skills deliberately kept local (via `.gitignore` or `.git/info/exclude`) tripped this on **every** sync run, producing perpetual noise in `~/.claude/sync-skills.log` for `check-gatb`, `grafana-policy-disclosure`, `morning`, and `slack-plugin-release-post`.

## Fix

Skip the reminder when `git check-ignore` matches the skill dir.

**Why `git check-ignore` over a dedicated skip-list:**
- **Single source of truth** - the same ignore rules that hide these dirs from `git status` now also silence the log; no second list to drift.
- **No name leak** - a skip-list committed to this *public* repo would re-expose the intentionally-uncommitted skill names. `.git/info/exclude` is local and never pushed.
- **Authoritative matching** - `git check-ignore` applies real gitignore semantics instead of reimplementing glob matching in bash.
- **Bonus** - also silences the long-standing `slack-plugin-release-post` false positive (it's `.gitignore`'d).

Out of scope: the separate `AFK` false positive, whose cause is a filename mismatch (`AFK-wip-SKILL.md` vs `SKILL.md`), not ignore rules.

## Validation

- `shellcheck` clean (exit 0), `bash -n` clean. Second commit fixes a pre-existing SC2115 warning (`rm -rf` empty-var guard) in a region this branch touches.
- Ran the script live: excluded skills produced no reminder; only `AFK` remained (expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)