### PR TITLE
docs(skills): add fresh-session guardrail to handoff skill

### DIFF
--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -13,3 +13,7 @@ Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs,
 Redact any sensitive information, such as API keys, passwords, or personally identifiable information.
 
 If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.
+
+Do NOT spawn a subagent or otherwise continue the handed-off work in the current session. A subagent runs inside this session and draws on its context budget, which defeats the purpose of a handoff. Your job ends at producing the document.
+
+After writing the document, print its absolute path and instruct the user to start a fresh session themselves: run `/clear`, then `read <path>`. This step is the user's to perform - the model cannot invoke `/clear` (it is a harness command, not a skill), and clearing wipes the conversation, so no in-session automation can carry the work across the boundary.


### PR DESCRIPTION
## What

Amends the `handoff` skill with two clarifications about how a handoff is meant to be completed:

- **Guardrail:** the skill must NOT spawn a subagent or continue the handed-off work in the current session. A subagent runs inside the session and draws on its context budget, defeating the purpose of a handoff. The skill's job ends at producing the document.
- **User instruction:** after writing the doc, print its absolute path and instruct the user to start a fresh session themselves (`/clear`, then `read <path>`). This step is inherently user-driven - the model cannot invoke `/clear` (a harness command, not a skill), and clearing wipes the conversation, so no in-session automation can carry work across the boundary.

## Why

Observed failure mode: `/handoff` correctly produced a compacted handoff doc but then kicked off a fresh *subagent* to do the work, rather than handing back to the user to start a fresh session. That consumes the current session's context budget - the opposite of the intent. These edits make the boundary explicit.