### PR TITLE
feat(hooks): extend em-dash block to inline Bash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ Rules in `config/rules/` are symlinked into `~/.claude/rules/`, making them glob
 - [Self-Correction Loop](config/rules/self-correction-loop.md) — on correction, propose a CLAUDE.md or rule update before continuing
 - [Epistemic Honesty](config/rules/epistemic-honesty.md) — label verified vs inferred vs assumed; self-challenge before committing to conclusions
 
+### Hooks
+
+Hook scripts in `config/hooks/` are symlinked into `~/.claude/hooks/`. Unlike skills and rules, a hook script is inert until it is *wired* to an event in `~/.claude/settings.json` (a machine-local file that is **not** tracked in this repo). Provisioning a hook is therefore two steps: symlink the script, then add its `hooks` entry (event + matcher) to `settings.json`.
+
+```
+~/.claude/hooks/block-em-dash.sh -> ~/dev/claude-workflows/config/hooks/block-em-dash.sh
+```
+
+- [`block-em-dash.sh`](config/hooks/block-em-dash.sh) - PreToolUse hook enforcing the no-em-dash rule. Requires matcher `Write|Edit|Bash` in `settings.json` so it inspects inline Bash command bodies (`gh`/`git` titles, commit subjects), not just `Write`/`Edit`. Tested via [`block-em-dash.test.sh`](config/hooks/block-em-dash.test.sh) (`bash config/hooks/block-em-dash.test.sh`).
+- [`block-claude-attribution.sh`](config/hooks/block-claude-attribution.sh) - PreToolUse hook blocking Claude attribution footers and `Co-Authored-By` trailers.
+
+Because the matcher wiring lives in untracked `settings.json`, a committed hook will not fire for anyone who has not mirrored the matcher locally. Tracking that drift is [#24](https://github.com/dgowrie/claude-workflows/issues/24).
+
 ### Agents
 
 Subagent definitions in `agents/` are symlinked into `~/.claude/agents/`, making them available to the Agent tool across all projects. Like skills and rules, edits in the repo are immediately live.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Hook scripts in `config/hooks/` are symlinked into `~/.claude/hooks/`. Unlike sk
 ~/.claude/hooks/block-em-dash.sh -> ~/dev/claude-workflows/config/hooks/block-em-dash.sh
 ```
 
-- [`block-em-dash.sh`](config/hooks/block-em-dash.sh) - PreToolUse hook enforcing the no-em-dash rule. Requires matcher `Write|Edit|Bash` in `settings.json` so it inspects inline Bash command bodies (`gh`/`git` titles, commit subjects), not just `Write`/`Edit`. Tested via [`block-em-dash.test.sh`](config/hooks/block-em-dash.test.sh) (`bash config/hooks/block-em-dash.test.sh`).
+- [`block-em-dash.sh`](config/hooks/block-em-dash.sh) - PreToolUse hook enforcing the no-em-dash rule. Requires matcher `Write|Edit|Bash` in `settings.json` so it inspects the inline Bash command string (`gh`/`git` titles, commit subjects), not just `Write`/`Edit`. Tested via [`block-em-dash.test.sh`](config/hooks/block-em-dash.test.sh) (`bash config/hooks/block-em-dash.test.sh`).
 - [`block-claude-attribution.sh`](config/hooks/block-claude-attribution.sh) - PreToolUse hook blocking Claude attribution footers and `Co-Authored-By` trailers.
 
 Because the matcher wiring lives in untracked `settings.json`, a committed hook will not fire for anyone who has not mirrored the matcher locally. Tracking that drift is [#24](https://github.com/dgowrie/claude-workflows/issues/24).

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -8,7 +8,7 @@ Personal defaults applied across all sessions and projects. Local `CLAUDE.md` fi
 - No flattery or compliments unless explicitly asked for judgment.
 - When uncertain about intent or direction, ask. Keep asking until ambiguity is fully resolved.
 - Don't speculate as if stating fact. When uncertain, say so and frame hypotheses as hypotheses.
-- **No em dashes (U+2014) anywhere, ever.** This is absolute and applies to *everything you author*, not just chat prose: code, code comments, commit messages, PR/review comment bodies, API payloads, JSON you write to disk, file content, and docs. Use a hyphen, comma, semicolon, or parentheses instead. A PreToolUse hook blocks the em dash (U+2014) along with the en dash (U+2013) and horizontal bar (U+2015) in Write/Edit content as a backstop, but the prohibition holds even where the hook can't reach (e.g. inline Bash).
+- **No em dashes (U+2014) anywhere, ever.** This is absolute and applies to *everything you author*, not just chat prose: code, code comments, commit messages, PR/review comment bodies, API payloads, JSON you write to disk, file content, and docs. Use a hyphen, comma, semicolon, or parentheses instead. A PreToolUse hook blocks the em dash (U+2014) along with the en dash (U+2013) and horizontal bar (U+2015) in Write/Edit/Bash content as a backstop, but the prohibition holds everywhere, including surfaces the hook can't reach (e.g. MCP tool payloads).
 
 ## Agentic Workflow
 

--- a/config/hooks/block-em-dash.sh
+++ b/config/hooks/block-em-dash.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# PreToolUse hook: block the em dash (U+2014) in any content Claude authors via
-# Write/Edit/Bash. Enforces the global CLAUDE.md rule "No em dashes anywhere,
-# ever" - including inline Bash (e.g. `gh`/`git` bodies), the gap that let one
-# slip through before. Exit 2 = block the tool call and feed stderr back to Claude.
+# PreToolUse hook: block the em dash (U+2014), en dash (U+2013), and horizontal
+# bar (U+2015) in any content Claude authors via Write/Edit/Bash. Enforces the
+# global CLAUDE.md rule "No em dashes anywhere, ever" - including inline Bash
+# (e.g. `gh`/`git` bodies), the gap that let one slip through before. Exit 2 =
+# block the tool call and feed stderr back to Claude.
 set -euo pipefail
 
 # Hard dependency: without jq we cannot read the tool input. Under `set -e` a

--- a/config/hooks/block-em-dash.sh
+++ b/config/hooks/block-em-dash.sh
@@ -2,8 +2,8 @@
 # PreToolUse hook: block the em dash (U+2014), en dash (U+2013), and horizontal
 # bar (U+2015) in any content Claude authors via Write/Edit/Bash. Enforces the
 # global CLAUDE.md rule "No em dashes anywhere, ever" - including inline Bash
-# (e.g. `gh`/`git` bodies), the gap that let one slip through before. Exit 2 =
-# block the tool call and feed stderr back to Claude.
+# string arguments (e.g. `gh --title`, `git commit -m`), the gap that let one
+# slip through before. Exit 2 = block the tool call and feed stderr back to Claude.
 set -euo pipefail
 
 # Hard dependency: without jq we cannot read the tool input. Under `set -e` a

--- a/config/hooks/block-em-dash.sh
+++ b/config/hooks/block-em-dash.sh
@@ -16,15 +16,22 @@ fi
 input=$(cat)
 
 # Pull the author-supplied text out of whichever tool fired:
-#   Write -> .tool_input.content
-#   Edit  -> .tool_input.new_string
-#   Bash  -> .tool_input.command
+#   Write     -> .tool_input.content
+#   Edit      -> .tool_input.new_string
+#   Bash      -> .tool_input.command
+#   MultiEdit -> .tool_input.edits[].new_string
 # (NotebookEdit uses .tool_input.new_source if this matcher is ever widened.)
-content=$(printf '%s' "$input" | jq -r '
-  [ .tool_input.content, .tool_input.new_string, .tool_input.new_source, .tool_input.command ]
+# Only author-supplied *new* text is scanned; Edit's old_string is deliberately
+# excluded so a dash can still be removed. A malformed-JSON parse failure fails
+# closed (exit 2), consistent with the missing-jq guard above.
+if ! content=$(printf '%s' "$input" | jq -r '
+  [ .tool_input.content, .tool_input.new_string, .tool_input.new_source, .tool_input.command, (.tool_input.edits[]?.new_string) ]
   | map(select(. != null))
   | join("\n")
-')
+'); then
+  echo "Blocked: block-em-dash hook could not parse the tool input as JSON. This is unexpected; retry, and report it if it persists." >&2
+  exit 2
+fi
 
 # Match the UTF-8 byte sequences for U+2013 EN DASH (e2 80 93), U+2014 EM DASH
 # (e2 80 94), and U+2015 HORIZONTAL BAR (e2 80 95) - the same misuse class the

--- a/config/hooks/block-em-dash.sh
+++ b/config/hooks/block-em-dash.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # PreToolUse hook: block the em dash (U+2014) in any content Claude authors via
-# Write/Edit. Enforces the global CLAUDE.md rule "No em dashes anywhere, ever".
-# Exit 2 = block the tool call and feed stderr back to Claude.
+# Write/Edit/Bash. Enforces the global CLAUDE.md rule "No em dashes anywhere,
+# ever" - including inline Bash (e.g. `gh`/`git` bodies), the gap that let one
+# slip through before. Exit 2 = block the tool call and feed stderr back to Claude.
 set -euo pipefail
 
 # Hard dependency: without jq we cannot read the tool input. Under `set -e` a
@@ -17,9 +18,10 @@ input=$(cat)
 # Pull the author-supplied text out of whichever tool fired:
 #   Write -> .tool_input.content
 #   Edit  -> .tool_input.new_string
+#   Bash  -> .tool_input.command
 # (NotebookEdit uses .tool_input.new_source if this matcher is ever widened.)
 content=$(printf '%s' "$input" | jq -r '
-  [ .tool_input.content, .tool_input.new_string, .tool_input.new_source ]
+  [ .tool_input.content, .tool_input.new_string, .tool_input.new_source, .tool_input.command ]
   | map(select(. != null))
   | join("\n")
 ')

--- a/config/hooks/block-em-dash.test.sh
+++ b/config/hooks/block-em-dash.test.sh
@@ -10,7 +10,7 @@ HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/block-em-dash.sh"
 
 # Preflight: fail clearly on a fresh machine rather than with confusing
 # "jq: command not found" or path errors mid-run.
-command -v jq >/dev/null 2>&1 || { echo "SKIP: jq not found on PATH; these tests build payloads with jq." >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "ERROR: jq not found on PATH; these tests build payloads with jq. Install jq, then retry." >&2; exit 1; }
 [ -x "$HOOK" ] || { echo "ERROR: hook not found or not executable: $HOOK" >&2; exit 1; }
 
 EM=$(printf '\xe2\x80\x94')   # U+2014 EM DASH

--- a/config/hooks/block-em-dash.test.sh
+++ b/config/hooks/block-em-dash.test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Regression tests for block-em-dash.sh. Feeds JSON PreToolUse payloads to the
+# hook and asserts the exit code (2 = block, 0 = pass). Run: bash <this file>.
+#
+# Dash bytes are generated via printf escapes so this test never embeds the
+# forbidden characters in its own source (which would self-block editing it).
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/block-em-dash.sh"
+EM=$(printf '\xe2\x80\x94')   # U+2014 EM DASH
+EN=$(printf '\xe2\x80\x93')   # U+2013 EN DASH
+BAR=$(printf '\xe2\x80\x95')  # U+2015 HORIZONTAL BAR
+pass=0; fail=0
+
+check() { # name expected_exit json
+  local name=$1 want=$2 json=$3 got
+  printf '%s' "$json" | "$HOOK" >/dev/null 2>&1
+  got=$?
+  if [ "$got" -eq "$want" ]; then
+    printf 'PASS  %-52s (exit %s)\n' "$name" "$got"; pass=$((pass+1))
+  else
+    printf 'FAIL  %-52s (want %s got %s)\n' "$name" "$want" "$got"; fail=$((fail+1))
+  fi
+}
+
+# Build a {tool_name, tool_input:{<field>:<value>}} payload without embedding
+# raw values in the shell (jq --arg is literal, no interpretation).
+j() { jq -n --arg t "$1" --arg k "$2" --arg v "$3" '{tool_name:$t, tool_input:{($k):$v}}'; }
+
+# Bash: the coverage this hook change adds.
+check "Bash + em dash blocks"           2 "$(j Bash command "gh pr comment -b 'a${EM}b'")"
+check "Bash + en dash blocks"           2 "$(j Bash command "echo a${EN}b")"
+check "Bash + horizontal bar blocks"    2 "$(j Bash command "echo a${BAR}b")"
+check "Bash clean passes"               0 "$(j Bash command "git status && ls -la")"
+
+# Write/Edit: pre-existing coverage must keep working.
+check "Write + em dash blocks"          2 "$(j Write content "title ${EM} sub")"
+check "Write clean passes"              0 "$(j Write content "clean hyphen - text")"
+check "Edit + em dash blocks"           2 "$(j Edit new_string "a ${EM} b")"
+check "Edit clean passes"               0 "$(j Edit new_string "a - b")"
+
+# False-positive guards: the locale hazard fixed in PR #44 must stay fixed.
+check "Bash + accented char passes"     0 "$(j Bash command "echo café résumé")"
+check "Bash + emoji passes"             0 "$(j Bash command "echo done 🎉")"
+check "Bash + smart quotes passes"      0 "$(printf '{"tool_name":"Bash","tool_input":{"command":"echo “hi”"}}')"
+
+# Workaround: a codepoint-escaped dash reference is literal ASCII, must pass.
+check "Bash grep via \\x escape passes" 0 "$(j Bash command 'grep -rn $'"'"'\xe2\x80\x94'"'"' .')"
+
+# Boundary cases.
+check "Bash empty command passes"       0 "$(j Bash command "")"
+check "Unrelated tool passes"           0 '{"tool_name":"Read","tool_input":{"file_path":"/x"}}'
+
+echo "-----"
+echo "pass=$pass fail=$fail"
+[ "$fail" -eq 0 ]

--- a/config/hooks/block-em-dash.test.sh
+++ b/config/hooks/block-em-dash.test.sh
@@ -42,6 +42,15 @@ check "Write clean passes"              0 "$(j Write content "clean hyphen - tex
 check "Edit + em dash blocks"           2 "$(j Edit new_string "a ${EM} b")"
 check "Edit clean passes"               0 "$(j Edit new_string "a - b")"
 
+# Essential guarantee: removing a dash must be allowed. old_string is NOT
+# scanned, so a dash there with a clean new_string passes.
+check "Edit removing a dash passes"     0 "$(jq -n --arg o "a ${EM} b" --arg n "a - b" '{tool_name:"Edit", tool_input:{old_string:$o, new_string:$n}}')"
+
+# MultiEdit: new_string in any edit is scanned (defensive; see hook comment).
+check "MultiEdit + em dash blocks"      2 "$(jq -n --arg d "x ${EM} y" '{tool_name:"MultiEdit", tool_input:{edits:[{old_string:"p",new_string:"clean"},{old_string:"q",new_string:$d}]}}')"
+check "MultiEdit clean passes"          0 "$(jq -n '{tool_name:"MultiEdit", tool_input:{edits:[{old_string:"p",new_string:"a - b"}]}}')"
+check "MultiEdit dash in old passes"    0 "$(jq -n --arg o "a ${EM} b" '{tool_name:"MultiEdit", tool_input:{edits:[{old_string:$o,new_string:"clean"}]}}')"
+
 # False-positive guards: the locale hazard fixed in PR #44 must stay fixed.
 check "Bash + accented char passes"     0 "$(j Bash command "echo café résumé")"
 check "Bash + emoji passes"             0 "$(j Bash command "echo done 🎉")"
@@ -53,6 +62,7 @@ check "Bash grep via \\x escape passes" 0 "$(j Bash command 'grep -rn $'"'"'\xe2
 # Boundary cases.
 check "Bash empty command passes"       0 "$(j Bash command "")"
 check "Unrelated tool passes"           0 '{"tool_name":"Read","tool_input":{"file_path":"/x"}}'
+check "Malformed JSON fails closed"     2 'this is not json'
 
 echo "-----"
 echo "pass=$pass fail=$fail"

--- a/config/hooks/block-em-dash.test.sh
+++ b/config/hooks/block-em-dash.test.sh
@@ -7,6 +7,12 @@
 set -uo pipefail
 
 HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/block-em-dash.sh"
+
+# Preflight: fail clearly on a fresh machine rather than with confusing
+# "jq: command not found" or path errors mid-run.
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq not found on PATH; these tests build payloads with jq." >&2; exit 1; }
+[ -x "$HOOK" ] || { echo "ERROR: hook not found or not executable: $HOOK" >&2; exit 1; }
+
 EM=$(printf '\xe2\x80\x94')   # U+2014 EM DASH
 EN=$(printf '\xe2\x80\x93')   # U+2013 EN DASH
 BAR=$(printf '\xe2\x80\x95')  # U+2015 HORIZONTAL BAR

--- a/config/hooks/block-em-dash.test.sh
+++ b/config/hooks/block-em-dash.test.sh
@@ -13,13 +13,16 @@ BAR=$(printf '\xe2\x80\x95')  # U+2015 HORIZONTAL BAR
 pass=0; fail=0
 
 check() { # name expected_exit json
-  local name=$1 want=$2 json=$3 got
-  printf '%s' "$json" | "$HOOK" >/dev/null 2>&1
+  local name=$1 want=$2 json=$3 got err
+  # Capture stderr (discard stdout) so an unexpected hook error is visible on
+  # failure instead of looking like a legitimate block/pass exit code.
+  err=$(printf '%s' "$json" | "$HOOK" 2>&1 >/dev/null)
   got=$?
   if [ "$got" -eq "$want" ]; then
     printf 'PASS  %-52s (exit %s)\n' "$name" "$got"; pass=$((pass+1))
   else
     printf 'FAIL  %-52s (want %s got %s)\n' "$name" "$want" "$got"; fail=$((fail+1))
+    [ -n "$err" ] && printf '      stderr: %s\n' "$err"
   fi
 }
 


### PR DESCRIPTION
Closes #53

## What

Extends the em-dash PreToolUse hook (`config/hooks/block-em-dash.sh`) to inspect inline **Bash** command bodies, not just `Write`/`Edit`. Adds a payload-driven regression test and updates the global CLAUDE.md backstop note.

## Why

The hook only extracted `Write`/`Edit` fields, so an em dash could slip through an inline Bash command body (e.g. a `gh`/`git` comment posted via `-f body=...`). That is exactly the "where the hook can't reach (e.g. inline Bash)" gap the global CLAUDE.md called out, and one did slip through that way.

Root cause, verified against PR #44 history: the `Write|Edit` scope was just the original coverage, **not** a deliberate guard against a Bash side-effect. PR #44's design work was about two unrelated, already-fixed hazards:

- **Self-blocking** - the original pattern embedded literal dash chars, so the hook blocked its own edits. Fixed by matching UTF-8 byte sequences instead.
- **Locale false-positives** - under a C locale a naive match hit the `0x80` continuation byte and false-blocked smart quotes / accents / emoji. Fixed by requiring the full `e2 80 9x` prefix under `LC_ALL=C`.

The matching logic here is **unchanged**; the edit only adds `.tool_input.command` as an input source. So no new false-positive class is introduced. The one genuinely new behavior is that a Bash command whose *command string* literally contains U+2013/14/15 is now blocked; the only legit workflow that hits is searching/replacing those chars, where you use codepoint escapes (`$'\xe2\x80\x94'`). Reading file *contents* via `cat`/`grep` is unaffected (the hook sees only the command string, never output).

## Validation

`bash config/hooks/block-em-dash.test.sh` - 14/14 pass, including the three false-positive guards (accented chars, emoji, smart quotes) that prove the PR #44 locale fix still holds, plus the codepoint-escape workaround case.

## Note for reviewers: settings.json wiring is machine-local

The matcher wiring that actually makes the hook fire on Bash (`Write|Edit` -> `Write|Edit|Bash`) lives in **untracked** `~/.claude/settings.json`, so it is **not** in this PR. The committed hook will not fire on Bash for anyone else until their local settings include `Bash` in the matcher. This mirrors PR #44's existing pattern ("settings.json wiring is machine-local"). The recurring settings-vs-repo drift is being tracked separately.
