### PR TITLE
feat(config): track a settings template + validate hook wiring (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Claude Code's built-in persistence (memory, plans) is useful but fragile: memori
 ## Structure
 
 ```
-config/        Global CLAUDE.md, rules, hooks, and settings.json, symlinked into ~/.claude/
-config/scripts/ Provisioning + drift checks for settings.json and hook wiring (see its README)
+config/        Global CLAUDE.md, rules, and hooks, symlinked into ~/.claude/
+config/scripts/ Settings template + hook-wiring checks (see its README)
 internals/     How Claude Code works under the hood
 workflows/     Patterns and practices for effective use
 explorations/  Session notes and behavioral findings

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Rules in `config/rules/` are symlinked into `~/.claude/rules/`, making them glob
 
 ### Hooks
 
-Hook scripts in `config/hooks/` are symlinked into `~/.claude/hooks/`. Unlike skills and rules, a hook script is inert until it is *wired* to an event in `~/.claude/settings.json` (a machine-local file that is **not** tracked in this repo). Provisioning a hook is therefore two steps: symlink the script, then add its `hooks` entry (event + matcher) to `settings.json`.
+Hook scripts in `config/hooks/` are symlinked into `~/.claude/hooks/`. Unlike skills and rules, a hook script is inert until it is *wired* to an event in `~/.claude/settings.json` (a machine-local file that is **not** tracked in this repo, since it also holds personal posture prefs). Provisioning a hook is therefore two steps: symlink the script, then add its `hooks` entry (event + matcher) to `settings.json`. The tracked template [`config/settings.example.json`](config/settings.example.json) carries the reviewable wiring; see [`config/scripts/`](config/scripts/README.md).
 
 ```
 ~/.claude/hooks/block-em-dash.sh -> ~/dev/claude-workflows/config/hooks/block-em-dash.sh
@@ -81,7 +81,7 @@ Hook scripts in `config/hooks/` are symlinked into `~/.claude/hooks/`. Unlike sk
 - [`block-em-dash.sh`](config/hooks/block-em-dash.sh) - PreToolUse hook enforcing the no-em-dash rule. Requires matcher `Write|Edit|Bash` in `settings.json` so it inspects the inline Bash command string (`gh`/`git` titles, commit subjects), not just `Write`/`Edit`. Tested via [`block-em-dash.test.sh`](config/hooks/block-em-dash.test.sh) (`bash config/hooks/block-em-dash.test.sh`).
 - [`block-claude-attribution.sh`](config/hooks/block-claude-attribution.sh) - PreToolUse hook blocking Claude attribution footers and `Co-Authored-By` trailers.
 
-Because the matcher wiring lives in untracked `settings.json`, a committed hook will not fire for anyone who has not mirrored the matcher locally. Tracking that drift is [#24](https://github.com/dgowrie/claude-workflows/issues/24).
+Because the matcher wiring lives in untracked `settings.json`, a committed hook will not fire for anyone who has not mirrored the matcher locally. [#24](https://github.com/dgowrie/claude-workflows/issues/24) closes that gap: `config/settings.example.json` tracks the wiring, and `config/scripts/validate-hook-wiring.sh` fails if any committed hook is unwired in a given `settings.json` (tracked template or live).
 
 ### Agents
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Claude Code's built-in persistence (memory, plans) is useful but fragile: memori
 ## Structure
 
 ```
-config/        Global CLAUDE.md and rules, symlinked into ~/.claude/
+config/        Global CLAUDE.md, rules, hooks, and settings.json, symlinked into ~/.claude/
+config/scripts/ Provisioning + drift checks for settings.json and hook wiring (see its README)
 internals/     How Claude Code works under the hood
 workflows/     Patterns and practices for effective use
 explorations/  Session notes and behavioral findings

--- a/config/scripts/README.md
+++ b/config/scripts/README.md
@@ -65,7 +65,7 @@ private posture keys). After `--init`, add your posture keys by hand:
 ```jsonc
 {
   // ...copied from settings.example.json (hooks, attribution)...
-  "model": "claude-opus-4-8[1m]",
+  "model": "<your-model-id>",
   "theme": "dark",
   "sandbox": { "enabled": true, "mode": "auto-allow" },
   "skipDangerousModePermissionPrompt": true,

--- a/config/scripts/README.md
+++ b/config/scripts/README.md
@@ -1,0 +1,79 @@
+# config/scripts
+
+Tooling that keeps the tracked Claude Code config in `config/` from drifting away
+from what is actually live in `~/.claude/`.
+
+## Why this exists (issue #24)
+
+Hook scripts, rules, skills, and agents in this repo are symlinked into `~/.claude/`,
+so edits are immediately live. `~/.claude/settings.json` was the exception: a regular,
+untracked file. It holds the *hook wiring* (the `PreToolUse` matchers that decide
+whether a committed hook actually fires) plus model/theme/sandbox prefs. Because it
+was untracked, a committed hook could silently never run, and the settings could
+drift from the repo with no record.
+
+Two pieces close that gap:
+
+1. `config/settings.json` is the tracked source of truth, symlinked to
+   `~/.claude/settings.json` (approach A).
+2. `validate-hook-wiring.sh` asserts every committed hook is actually wired
+   (approach B), so the tracked settings cannot fall out of sync with the hooks.
+
+## Scripts
+
+- `install-settings.sh`: symlink `~/.claude/settings.json` to `config/settings.json`; `--check` reports drift.
+- `validate-hook-wiring.sh`: fail if any `config/hooks/*.sh` is unwired or wired with an empty matcher.
+
+Each has a companion `*.test.sh` (plain bash, no framework). Run them directly:
+
+```bash
+bash config/scripts/validate-hook-wiring.test.sh
+bash config/scripts/install-settings.test.sh
+```
+
+### install-settings.sh
+
+```bash
+# Link the tracked settings into ~/.claude (backs up any existing file first)
+bash config/scripts/install-settings.sh
+
+# Report link status + drift without changing anything (nonzero exit if drifted)
+bash config/scripts/install-settings.sh --check
+```
+
+Portable hook paths: `config/settings.json` uses `$HOME/.claude/hooks/...` rather
+than an absolute `/Users/<you>/...` path. Claude Code runs hook commands through
+`sh -c`, which expands `$HOME`, so the same tracked file works on any machine.
+
+#### Known caveat: `/config` may clobber the symlink
+
+It is **not confirmed** whether Claude Code's own settings writer (`/config`, or
+changing the theme in the TUI) writes *through* the symlink or *replaces* the file.
+If it replaces it, `~/.claude/settings.json` silently becomes a regular file again
+and the link to the repo is lost.
+
+`install-settings.sh --check` detects exactly this: it flags "a regular file where a
+symlink is expected" and preserves the current file as a `.backup.<timestamp>` when
+you re-link, so no `/config` edits are lost. To confirm the behavior on your setup:
+link the file, run `/config` to change the theme, then run `--check` and see whether
+the symlink survived.
+
+### validate-hook-wiring.sh
+
+```bash
+# Check the tracked settings wires every tracked hook (defaults shown)
+bash config/scripts/validate-hook-wiring.sh
+# Or check an arbitrary settings file / hooks dir:
+bash config/scripts/validate-hook-wiring.sh ~/.claude/settings.json config/hooks
+```
+
+It checks **presence + a non-empty matcher** for each hook, not whether the matcher
+covers the "right" tools. Inferring intended tools from a script is brittle, and
+tracking `settings.json` already makes matcher edits visible in review. A future
+job could add a per-hook `# required-matcher:` annotation for stricter checks.
+
+## Adding a new hook
+
+1. Add `config/hooks/<name>.sh` and symlink it: `ln -s ~/dev/claude-workflows/config/hooks/<name>.sh ~/.claude/hooks/<name>.sh`
+2. Wire it in `config/settings.json` under `hooks.PreToolUse` with a matcher.
+3. Run `bash config/scripts/validate-hook-wiring.sh`; it fails until the hook is wired.

--- a/config/scripts/README.md
+++ b/config/scripts/README.md
@@ -1,28 +1,42 @@
 # config/scripts
 
-Tooling that keeps the tracked Claude Code config in `config/` from drifting away
-from what is actually live in `~/.claude/`.
+Tooling that keeps committed Claude Code hooks from silently going inert, without
+publishing personal settings to this public repo.
 
 ## Why this exists (issue #24)
 
 Hook scripts, rules, skills, and agents in this repo are symlinked into `~/.claude/`,
-so edits are immediately live. `~/.claude/settings.json` was the exception: a regular,
-untracked file. It holds the *hook wiring* (the `PreToolUse` matchers that decide
-whether a committed hook actually fires) plus model/theme/sandbox prefs. Because it
-was untracked, a committed hook could silently never run, and the settings could
-drift from the repo with no record.
+so edits are immediately live. `~/.claude/settings.json` is the exception. It holds
+the *hook wiring* (the `PreToolUse` matchers that decide whether a committed hook
+actually fires) alongside personal posture prefs (`model`, `theme`, `sandbox`,
+`skipDangerousModePermissionPrompt`, `skipAutoPermissionPrompt`, ...). Two facts
+make it awkward to track:
 
-Two pieces close that gap:
+- The posture prefs are personal and this is a **public** repo, so the live file
+  can't just be committed or symlinked to a tracked copy.
+- At user-global scope there is a single `settings.json` and **no** private
+  overlay: a user-level `~/.claude/settings.local.json` is **not** honored for
+  these keys (verified). So public and private keys can't be split across two
+  user-scope files either.
 
-1. `config/settings.json` is the tracked source of truth, symlinked to
-   `~/.claude/settings.json` (approach A).
-2. `validate-hook-wiring.sh` asserts every committed hook is actually wired
-   (approach B), so the tracked settings cannot fall out of sync with the hooks.
+So instead of tracking the live file, we track a **template** and validate the
+live file's wiring:
+
+1. `config/settings.example.json` is the tracked, reviewable template. It holds
+   only shareable keys: the hook wiring plus the no-attribution policy
+   (`includeCoAuthoredBy`, `attribution`). It carries **no** posture keys.
+2. You copy it once to the untracked `~/.claude/settings.json` and add your
+   private posture keys there.
+3. `validate-hook-wiring.sh` asserts every committed hook is actually wired, run
+   against both the template (is the checked-in wiring complete?) and your live
+   file (is your real config still wiring every hook?).
 
 ## Scripts
 
-- `install-settings.sh`: symlink `~/.claude/settings.json` to `config/settings.json`; `--check` reports drift.
-- `validate-hook-wiring.sh`: fail if any `config/hooks/*.sh` is unwired or wired with an empty matcher.
+- `install-settings.sh`: `--init` copies the template to `~/.claude/settings.json`
+  (only if absent); `--check` (default) verifies the live file wires every hook.
+- `validate-hook-wiring.sh`: fail if any `config/hooks/*.sh` is unwired or wired
+  with an empty matcher in a given settings file.
 
 Each has a companion `*.test.sh` (plain bash, no framework). Run them directly:
 
@@ -31,37 +45,50 @@ bash config/scripts/validate-hook-wiring.test.sh
 bash config/scripts/install-settings.test.sh
 ```
 
+> The test suites write fixtures under `mktemp -d`. Run them outside a restrictive
+> sandbox (e.g. Claude Code's `auto-allow` sandbox blocks writes to the system
+> temp dir), or they fail with "Operation not permitted".
+
 ### install-settings.sh
 
 ```bash
-# Link the tracked settings into ~/.claude (backs up any existing file first)
-bash config/scripts/install-settings.sh
+# First-time setup: copy the template into ~/.claude (only if it does not exist)
+bash config/scripts/install-settings.sh --init
 
-# Report link status + drift without changing anything (nonzero exit if drifted)
+# Verify the live settings still wire every committed hook (default; read-only)
 bash config/scripts/install-settings.sh --check
 ```
 
-Portable hook paths: `config/settings.json` uses `$HOME/.claude/hooks/...` rather
-than an absolute `/Users/<you>/...` path. Claude Code runs hook commands through
-`sh -c`, which expands `$HOME`, so the same tracked file works on any machine.
+`--init` never overwrites an existing `~/.claude/settings.json` (it holds your
+private posture keys). After `--init`, add your posture keys by hand:
 
-#### Known caveat: `/config` may clobber the symlink
+```jsonc
+{
+  // ...copied from settings.example.json (hooks, attribution)...
+  "model": "claude-opus-4-8[1m]",
+  "theme": "dark",
+  "sandbox": { "enabled": true, "mode": "auto-allow" },
+  "skipDangerousModePermissionPrompt": true,
+  "skipAutoPermissionPrompt": true
+}
+```
 
-It is **not confirmed** whether Claude Code's own settings writer (`/config`, or
-changing the theme in the TUI) writes *through* the symlink or *replaces* the file.
-If it replaces it, `~/.claude/settings.json` silently becomes a regular file again
-and the link to the repo is lost.
+These posture keys are intentionally **not** tracked. Keep them only in the live
+file.
 
-`install-settings.sh --check` detects exactly this: it flags "a regular file where a
-symlink is expected" and preserves the current file as a `.backup.<timestamp>` when
-you re-link, so no `/config` edits are lost. To confirm the behavior on your setup:
-link the file, run `/config` to change the theme, then run `--check` and see whether
-the symlink survived.
+`--check` errors if the live file is missing (`NOT INSTALLED`) or invalid JSON,
+fails if any committed hook is unwired, and prints a non-fatal `note:` if the live
+`hooks` block has drifted from the template (your matchers may legitimately
+differ; the note just keeps the template honest).
+
+Portable hook paths: `config/settings.example.json` uses `$HOME/.claude/hooks/...`
+rather than an absolute `/Users/<you>/...` path. Claude Code runs hook commands
+through `sh -c`, which expands `$HOME`, so the same template works on any machine.
 
 ### validate-hook-wiring.sh
 
 ```bash
-# Check the tracked settings wires every tracked hook (defaults shown)
+# Check the tracked template wires every committed hook (defaults shown)
 bash config/scripts/validate-hook-wiring.sh
 # Or check an arbitrary settings file / hooks dir:
 bash config/scripts/validate-hook-wiring.sh ~/.claude/settings.json config/hooks
@@ -69,11 +96,14 @@ bash config/scripts/validate-hook-wiring.sh ~/.claude/settings.json config/hooks
 
 It checks **presence + a non-empty matcher** for each hook, not whether the matcher
 covers the "right" tools. Inferring intended tools from a script is brittle, and
-tracking `settings.json` already makes matcher edits visible in review. A future
-job could add a per-hook `# required-matcher:` annotation for stricter checks.
+the tracked template already makes the intended matchers visible in review. A hook
+counts as wired if any `PreToolUse` command references its filename, tolerant of
+trailing args and shell prefixes (`sh -c '.../foo.sh'`, `bash .../foo.sh`). A
+future job could add a per-hook `# required-matcher:` annotation for stricter
+checks.
 
 ## Adding a new hook
 
 1. Add `config/hooks/<name>.sh` and symlink it: `ln -s ~/dev/claude-workflows/config/hooks/<name>.sh ~/.claude/hooks/<name>.sh`
-2. Wire it in `config/settings.json` under `hooks.PreToolUse` with a matcher.
-3. Run `bash config/scripts/validate-hook-wiring.sh`; it fails until the hook is wired.
+2. Wire it in `config/settings.example.json` under `hooks.PreToolUse` with a matcher, and in your live `~/.claude/settings.json`.
+3. Run `bash config/scripts/validate-hook-wiring.sh`; it fails until the template wires the hook.

--- a/config/scripts/install-settings.sh
+++ b/config/scripts/install-settings.sh
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
-# Link the tracked config/settings.json into ~/.claude, and check for drift.
+# Provision the tracked Claude Code settings template into ~/.claude, and check
+# that the live settings still wire every committed hook.
 #
-# claude-workflows #24: ~/.claude/settings.json holds the hook *wiring* that makes
-# committed hooks fire, plus model/theme/sandbox prefs. It was an untracked
-# regular file, so its state could drift from the repo silently. This script
-# makes it a symlink to the tracked config/settings.json (source of truth) and,
-# in --check mode, reports drift.
-#
-# KNOWN CAVEAT (unverified): Claude Code's own settings writer (e.g. `/config`,
-# changing the theme in the TUI) may REPLACE settings.json rather than write
-# through the symlink, silently turning it back into a regular file. --check
-# detects that case ("regular file where a symlink is expected") so it can be
-# re-linked; the pre-existing file is preserved as a .backup so no edits are lost.
+# claude-workflows #24: personal posture keys (model, theme, sandbox, skip*
+# prompts) must NOT be committed to this public repo, and at user-global scope
+# there is a single settings.json with no private overlay (verified: a user-level
+# settings.local.json is not honored for these keys). So instead of tracking or
+# symlinking the live file, we track a template, config/settings.example.json,
+# holding only shareable keys (hook wiring + attribution policy). You copy it once
+# to the untracked ~/.claude/settings.json (--init) and add your private posture
+# keys there. --check then asserts the live file still wires every committed hook.
 #
 # Usage:
-#   install-settings.sh          link settings.json (backs up any existing file)
-#   install-settings.sh --check  report link status + drift; nonzero if drifted
+#   install-settings.sh            (--check) verify live settings wire all hooks
+#   install-settings.sh --check    same as no args
+#   install-settings.sh --init     copy the template to ~/.claude/settings.json
+#                                   (only if it does not already exist)
 #
 # Override the target dir for testing:  CLAUDE_CONFIG_DIR=/tmp/fake ./install-settings.sh
 set -euo pipefail
@@ -23,81 +23,65 @@ set -euo pipefail
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 config_dir="$(cd "$here/.." && pwd)"
 
-source_file="$config_dir/settings.json"
+source_file="$config_dir/settings.example.json"
 target_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 target_file="$target_dir/settings.json"
 
-mode="link"
-if [ "${1:-}" = "--check" ]; then
-  mode="check"
-elif [ -n "${1:-}" ]; then
-  echo "usage: install-settings.sh [--check]" >&2
+mode="check"
+case "${1:-}" in
+  ""|--check) mode="check" ;;
+  --init)     mode="init" ;;
+  *) echo "usage: install-settings.sh [--check|--init]" >&2; exit 2 ;;
+esac
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: install-settings requires 'jq' on PATH." >&2
   exit 2
 fi
 
 if [ ! -f "$source_file" ]; then
-  echo "error: tracked settings not found: $source_file" >&2
+  echo "error: tracked settings template not found: $source_file" >&2
   exit 2
 fi
 
-# resolve_link <path> -> prints the symlink target (absolute) or empty if not a link
-resolve_link() {
-  if [ -L "$1" ]; then
-    local dest ; dest="$(readlink "$1")"
-    case "$dest" in
-      /*) printf '%s' "$dest" ;;
-      *)  printf '%s' "$(cd "$(dirname "$1")" && cd "$(dirname "$dest")" && pwd)/$(basename "$dest")" ;;
-    esac
-  fi
-}
-
 run_validation() {
-  bash "$here/validate-hook-wiring.sh" "$source_file" "$config_dir/hooks"
+  bash "$here/validate-hook-wiring.sh" "$1" "$config_dir/hooks"
 }
 
-if [ "$mode" = "check" ]; then
-  status=0
-  if [ -L "$target_file" ]; then
-    dest="$(resolve_link "$target_file")"
-    if [ "$dest" = "$source_file" ]; then
-      echo "ok: $target_file -> $source_file"
-    else
-      echo "WARN: $target_file is a symlink to '$dest', not the tracked $source_file" >&2
-      status=1
-    fi
-  elif [ -f "$target_file" ]; then
-    if cmp -s "$target_file" "$source_file"; then
-      echo "WARN: $target_file is a regular file (not a symlink) but its content matches the tracked file." >&2
-      echo "      A Claude Code settings write may have replaced the symlink. Re-run install-settings.sh to re-link." >&2
-    else
-      echo "DRIFT: $target_file is a regular file and differs from tracked $source_file." >&2
-      echo "      Reconcile the differences into the tracked file, then re-run install-settings.sh." >&2
-    fi
-    status=1
-  else
-    echo "NOT INSTALLED: $target_file does not exist. Run install-settings.sh to link it." >&2
-    status=1
+if [ "$mode" = "init" ]; then
+  # Never clobber an existing live file: it holds private posture keys.
+  if [ -e "$target_file" ] || [ -L "$target_file" ]; then
+    echo "exists: $target_file already present; refusing to overwrite." >&2
+    echo "        Reconcile by hand, or run install-settings.sh --check to verify wiring." >&2
+    exit 1
   fi
-  # Wiring must hold regardless of link status.
-  run_validation
-  exit "$status"
-fi
-
-# mode = link
-if [ -L "$target_file" ] && [ "$(resolve_link "$target_file")" = "$source_file" ]; then
-  echo "already linked: $target_file -> $source_file"
-  run_validation
+  mkdir -p "$target_dir"
+  cp "$source_file" "$target_file"
+  echo "created $target_file from $source_file"
+  echo "next: add your private posture keys (model, theme, sandbox, skip*) to $target_file;"
+  echo "      they are intentionally NOT tracked. See config/scripts/README.md."
+  run_validation "$target_file"
   exit 0
 fi
 
-mkdir -p "$target_dir"
-
-if [ -e "$target_file" ] || [ -L "$target_file" ]; then
-  backup="$target_file.backup.$(date +%Y%m%d%H%M%S)"
-  mv "$target_file" "$backup"
-  echo "backed up existing settings to $backup"
+# mode = check: the live file must exist and wire every committed hook.
+if [ ! -f "$target_file" ]; then
+  echo "NOT INSTALLED: $target_file does not exist. Run install-settings.sh --init to create it." >&2
+  exit 1
 fi
 
-ln -s "$source_file" "$target_file"
-echo "linked $target_file -> $source_file"
-run_validation
+if ! jq -e . "$target_file" >/dev/null 2>&1; then
+  echo "error: live settings is not valid JSON: $target_file" >&2
+  exit 2
+fi
+
+# Soft drift signal: the live hook wiring differs from the tracked template.
+# Non-fatal (your matchers may legitimately differ), but surfaces silent changes
+# so the template can be kept honest.
+if ! jq -e -s '.[0].hooks == .[1].hooks' "$target_file" "$source_file" >/dev/null; then
+  echo "note: live hooks differ from the tracked template ($source_file)." >&2
+  echo "      If intentional, update the template so review reflects reality." >&2
+fi
+
+# Hard guarantee (#24): every committed hook is actually wired in the LIVE file.
+run_validation "$target_file"

--- a/config/scripts/install-settings.sh
+++ b/config/scripts/install-settings.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Link the tracked config/settings.json into ~/.claude, and check for drift.
+#
+# claude-workflows #24: ~/.claude/settings.json holds the hook *wiring* that makes
+# committed hooks fire, plus model/theme/sandbox prefs. It was an untracked
+# regular file, so its state could drift from the repo silently. This script
+# makes it a symlink to the tracked config/settings.json (source of truth) and,
+# in --check mode, reports drift.
+#
+# KNOWN CAVEAT (unverified): Claude Code's own settings writer (e.g. `/config`,
+# changing the theme in the TUI) may REPLACE settings.json rather than write
+# through the symlink, silently turning it back into a regular file. --check
+# detects that case ("regular file where a symlink is expected") so it can be
+# re-linked; the pre-existing file is preserved as a .backup so no edits are lost.
+#
+# Usage:
+#   install-settings.sh          link settings.json (backs up any existing file)
+#   install-settings.sh --check  report link status + drift; nonzero if drifted
+#
+# Override the target dir for testing:  CLAUDE_CONFIG_DIR=/tmp/fake ./install-settings.sh
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+config_dir="$(cd "$here/.." && pwd)"
+
+source_file="$config_dir/settings.json"
+target_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+target_file="$target_dir/settings.json"
+
+mode="link"
+if [ "${1:-}" = "--check" ]; then
+  mode="check"
+elif [ -n "${1:-}" ]; then
+  echo "usage: install-settings.sh [--check]" >&2
+  exit 2
+fi
+
+if [ ! -f "$source_file" ]; then
+  echo "error: tracked settings not found: $source_file" >&2
+  exit 2
+fi
+
+# resolve_link <path> -> prints the symlink target (absolute) or empty if not a link
+resolve_link() {
+  if [ -L "$1" ]; then
+    local dest ; dest="$(readlink "$1")"
+    case "$dest" in
+      /*) printf '%s' "$dest" ;;
+      *)  printf '%s' "$(cd "$(dirname "$1")" && cd "$(dirname "$dest")" && pwd)/$(basename "$dest")" ;;
+    esac
+  fi
+}
+
+run_validation() {
+  bash "$here/validate-hook-wiring.sh" "$source_file" "$config_dir/hooks"
+}
+
+if [ "$mode" = "check" ]; then
+  status=0
+  if [ -L "$target_file" ]; then
+    dest="$(resolve_link "$target_file")"
+    if [ "$dest" = "$source_file" ]; then
+      echo "ok: $target_file -> $source_file"
+    else
+      echo "WARN: $target_file is a symlink to '$dest', not the tracked $source_file" >&2
+      status=1
+    fi
+  elif [ -f "$target_file" ]; then
+    if cmp -s "$target_file" "$source_file"; then
+      echo "WARN: $target_file is a regular file (not a symlink) but its content matches the tracked file." >&2
+      echo "      A Claude Code settings write may have replaced the symlink. Re-run install-settings.sh to re-link." >&2
+    else
+      echo "DRIFT: $target_file is a regular file and differs from tracked $source_file." >&2
+      echo "      Reconcile the differences into the tracked file, then re-run install-settings.sh." >&2
+    fi
+    status=1
+  else
+    echo "NOT INSTALLED: $target_file does not exist. Run install-settings.sh to link it." >&2
+    status=1
+  fi
+  # Wiring must hold regardless of link status.
+  run_validation
+  exit "$status"
+fi
+
+# mode = link
+if [ -L "$target_file" ] && [ "$(resolve_link "$target_file")" = "$source_file" ]; then
+  echo "already linked: $target_file -> $source_file"
+  run_validation
+  exit 0
+fi
+
+mkdir -p "$target_dir"
+
+if [ -e "$target_file" ] || [ -L "$target_file" ]; then
+  backup="$target_file.backup.$(date +%Y%m%d%H%M%S)"
+  mv "$target_file" "$backup"
+  echo "backed up existing settings to $backup"
+fi
+
+ln -s "$source_file" "$target_file"
+echo "linked $target_file -> $source_file"
+run_validation

--- a/config/scripts/install-settings.test.sh
+++ b/config/scripts/install-settings.test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Tests for install-settings.sh. Uses CLAUDE_CONFIG_DIR to redirect the target
+# away from the real ~/.claude, so tests never touch live config.
+#
+# Run: bash config/scripts/install-settings.test.sh
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script="$here/install-settings.sh"
+source_file="$(cd "$here/.." && pwd)/settings.json"
+
+pass=0
+fail=0
+ok()   { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf 'FAIL %s\n' "$1"; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# fresh install links the tracked file
+fake="$work/home1"
+out="$(CLAUDE_CONFIG_DIR="$fake" bash "$script" 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ] && [ -L "$fake/settings.json" ] \
+   && [ "$(readlink "$fake/settings.json")" = "$source_file" ]; then
+  ok "fresh install creates symlink to tracked settings"
+else
+  bad "fresh install (rc=$rc): $out"
+fi
+
+# re-running is idempotent (still linked, reports already linked)
+out="$(CLAUDE_CONFIG_DIR="$fake" bash "$script" 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -qF "already linked"; then
+  ok "second install is idempotent"
+else
+  bad "idempotent install (rc=$rc): $out"
+fi
+
+# --check on a good link passes
+out="$(CLAUDE_CONFIG_DIR="$fake" bash "$script" --check 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -qF "ok: $fake/settings.json"; then
+  ok "--check passes on a valid link"
+else
+  bad "--check on valid link (rc=$rc): $out"
+fi
+
+# existing regular file is backed up, then replaced by the symlink
+fake2="$work/home2"
+mkdir -p "$fake2"
+printf '{"model":"old"}\n' >"$fake2/settings.json"
+out="$(CLAUDE_CONFIG_DIR="$fake2" bash "$script" 2>&1)"; rc=$?
+backups=( "$fake2"/settings.json.backup.* )
+if [ "$rc" -eq 0 ] && [ -L "$fake2/settings.json" ] && [ -f "${backups[0]}" ] \
+   && grep -qF '"model":"old"' "${backups[0]}"; then
+  ok "existing regular file is backed up before linking"
+else
+  bad "backup-on-link (rc=$rc): $out"
+fi
+
+# clobber detection: a regular file where a symlink is expected -> nonzero,
+# and the message distinguishes "content matches" from "drift".
+fake3="$work/home3"
+mkdir -p "$fake3"
+cp "$source_file" "$fake3/settings.json"   # identical content, but a regular file
+out="$(CLAUDE_CONFIG_DIR="$fake3" bash "$script" --check 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qiF "regular file"; then
+  ok "--check flags a clobbered symlink (regular file, content matches)"
+else
+  bad "--check clobber-matches (rc=$rc): $out"
+fi
+
+fake4="$work/home4"
+mkdir -p "$fake4"
+printf '{"model":"drifted"}\n' >"$fake4/settings.json"
+out="$(CLAUDE_CONFIG_DIR="$fake4" bash "$script" --check 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qiF "DRIFT"; then
+  ok "--check reports DRIFT when a regular file differs"
+else
+  bad "--check drift (rc=$rc): $out"
+fi
+
+# --check when nothing is installed -> nonzero, NOT INSTALLED
+fake5="$work/home5"
+out="$(CLAUDE_CONFIG_DIR="$fake5" bash "$script" --check 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qiF "NOT INSTALLED"; then
+  ok "--check reports NOT INSTALLED when absent"
+else
+  bad "--check not-installed (rc=$rc): $out"
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/config/scripts/install-settings.test.sh
+++ b/config/scripts/install-settings.test.sh
@@ -7,84 +7,99 @@ set -uo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 script="$here/install-settings.sh"
-source_file="$(cd "$here/.." && pwd)/settings.json"
+example="$(cd "$here/.." && pwd)/settings.example.json"
 
 pass=0
 fail=0
-ok()   { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
-bad()  { fail=$((fail+1)); printf 'FAIL %s\n' "$1"; }
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s\n' "$1"; }
 
-work="$(mktemp -d)"
+# mktemp -d works without a template on GNU and modern macOS/BSD; the -t fallback
+# keeps older BSD mktemp happy too.
+work="$(mktemp -d 2>/dev/null || mktemp -d -t cc-install-test)"
 trap 'rm -rf "$work"' EXIT
 
-# fresh install links the tracked file
+# --init into an empty target dir copies the template verbatim (regular file)
 fake="$work/home1"
-out="$(CLAUDE_CONFIG_DIR="$fake" bash "$script" 2>&1)"; rc=$?
-if [ "$rc" -eq 0 ] && [ -L "$fake/settings.json" ] \
-   && [ "$(readlink "$fake/settings.json")" = "$source_file" ]; then
-  ok "fresh install creates symlink to tracked settings"
+out="$(CLAUDE_CONFIG_DIR="$fake" bash "$script" --init 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ] && [ -f "$fake/settings.json" ] && [ ! -L "$fake/settings.json" ] \
+   && cmp -s "$fake/settings.json" "$example"; then
+  ok "--init copies the template to an absent target"
 else
-  bad "fresh install (rc=$rc): $out"
+  bad "--init fresh (rc=$rc): $out"
 fi
 
-# re-running is idempotent (still linked, reports already linked)
-out="$(CLAUDE_CONFIG_DIR="$fake" bash "$script" 2>&1)"; rc=$?
-if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -qF "already linked"; then
-  ok "second install is idempotent"
+# --init refuses to overwrite an existing target (private posture must survive)
+printf '{"model":"private","hooks":{}}\n' >"$fake/settings.json"
+before="$(cat "$fake/settings.json")"
+out="$(CLAUDE_CONFIG_DIR="$fake" bash "$script" --init 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qiF "already present" \
+   && [ "$(cat "$fake/settings.json")" = "$before" ]; then
+  ok "--init refuses to overwrite an existing target"
 else
-  bad "idempotent install (rc=$rc): $out"
-fi
-
-# --check on a good link passes
-out="$(CLAUDE_CONFIG_DIR="$fake" bash "$script" --check 2>&1)"; rc=$?
-if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -qF "ok: $fake/settings.json"; then
-  ok "--check passes on a valid link"
-else
-  bad "--check on valid link (rc=$rc): $out"
-fi
-
-# existing regular file is backed up, then replaced by the symlink
-fake2="$work/home2"
-mkdir -p "$fake2"
-printf '{"model":"old"}\n' >"$fake2/settings.json"
-out="$(CLAUDE_CONFIG_DIR="$fake2" bash "$script" 2>&1)"; rc=$?
-backups=( "$fake2"/settings.json.backup.* )
-if [ "$rc" -eq 0 ] && [ -L "$fake2/settings.json" ] && [ -f "${backups[0]}" ] \
-   && grep -qF '"model":"old"' "${backups[0]}"; then
-  ok "existing regular file is backed up before linking"
-else
-  bad "backup-on-link (rc=$rc): $out"
-fi
-
-# clobber detection: a regular file where a symlink is expected -> nonzero,
-# and the message distinguishes "content matches" from "drift".
-fake3="$work/home3"
-mkdir -p "$fake3"
-cp "$source_file" "$fake3/settings.json"   # identical content, but a regular file
-out="$(CLAUDE_CONFIG_DIR="$fake3" bash "$script" --check 2>&1)"; rc=$?
-if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qiF "regular file"; then
-  ok "--check flags a clobbered symlink (regular file, content matches)"
-else
-  bad "--check clobber-matches (rc=$rc): $out"
-fi
-
-fake4="$work/home4"
-mkdir -p "$fake4"
-printf '{"model":"drifted"}\n' >"$fake4/settings.json"
-out="$(CLAUDE_CONFIG_DIR="$fake4" bash "$script" --check 2>&1)"; rc=$?
-if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qiF "DRIFT"; then
-  ok "--check reports DRIFT when a regular file differs"
-else
-  bad "--check drift (rc=$rc): $out"
+  bad "--init no-clobber (rc=$rc): $out"
 fi
 
 # --check when nothing is installed -> nonzero, NOT INSTALLED
-fake5="$work/home5"
-out="$(CLAUDE_CONFIG_DIR="$fake5" bash "$script" --check 2>&1)"; rc=$?
+fake2="$work/home2"
+out="$(CLAUDE_CONFIG_DIR="$fake2" bash "$script" --check 2>&1)"; rc=$?
 if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qiF "NOT INSTALLED"; then
   ok "--check reports NOT INSTALLED when absent"
 else
   bad "--check not-installed (rc=$rc): $out"
+fi
+
+# default (no args) behaves like --check
+out="$(CLAUDE_CONFIG_DIR="$fake2" bash "$script" 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qiF "NOT INSTALLED"; then
+  ok "no args defaults to --check"
+else
+  bad "default is check (rc=$rc): $out"
+fi
+
+# --check passes when the live file wires every committed hook (template + posture)
+fake3="$work/home3"
+mkdir -p "$fake3"
+jq '. + {model: "private", theme: "dark"}' "$example" >"$fake3/settings.json"
+out="$(CLAUDE_CONFIG_DIR="$fake3" bash "$script" --check 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -qiF "all hooks wired"; then
+  ok "--check passes when live wires all committed hooks"
+else
+  bad "--check valid (rc=$rc): $out"
+fi
+
+# --check soft-notes when live hooks differ from the template, but still passes
+# if the wiring is valid (all hooks present, non-empty matcher)
+fake4="$work/home4"
+mkdir -p "$fake4"
+jq '.hooks.PreToolUse[0].matcher = "Write"' "$example" >"$fake4/settings.json"
+out="$(CLAUDE_CONFIG_DIR="$fake4" bash "$script" --check 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -qiF "differ from the tracked template"; then
+  ok "--check soft-notes hook drift but passes on valid wiring"
+else
+  bad "--check soft drift (rc=$rc): $out"
+fi
+
+# --check fails when the live file is missing a committed hook's wiring
+fake5="$work/home5"
+mkdir -p "$fake5"
+jq 'del(.hooks.PreToolUse[1])' "$example" >"$fake5/settings.json"
+out="$(CLAUDE_CONFIG_DIR="$fake5" bash "$script" --check 2>&1)"; rc=$?
+if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -qiF "MISSING wiring"; then
+  ok "--check fails when a committed hook is unwired in live"
+else
+  bad "--check missing wiring (rc=$rc): $out"
+fi
+
+# --check errors clearly on invalid JSON in the live file
+fake6="$work/home6"
+mkdir -p "$fake6"
+printf '{not json\n' >"$fake6/settings.json"
+out="$(CLAUDE_CONFIG_DIR="$fake6" bash "$script" --check 2>&1)"; rc=$?
+if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -qiF "not valid JSON"; then
+  ok "--check errors on invalid live JSON"
+else
+  bad "--check invalid json (rc=$rc): $out"
 fi
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"

--- a/config/scripts/validate-hook-wiring.sh
+++ b/config/scripts/validate-hook-wiring.sh
@@ -49,11 +49,16 @@ fi
 
 # Every PreToolUse command with its matcher, one "<command>\t<matcher>" per line.
 # Skip null/empty commands so a malformed entry can't surface as the string "null".
+# Type guards (`?` and explicit array checks) keep valid-but-oddly-typed JSON
+# (e.g. "hooks": [] or "PreToolUse": {}) from crashing jq under `set -e`; such
+# structures are simply treated as "no wiring found".
 wired="$(jq -r '
-  (.hooks.PreToolUse // [])[]
-  | (.matcher // "") as $m
-  | (.hooks // [])[]
-  | select(.type == "command")
+  ((.hooks? // {}).PreToolUse? // []) as $groups
+  | (if ($groups | type) == "array" then $groups else [] end)[]
+  | (.matcher? // "") as $m
+  | (.hooks? // [])
+  | (if type == "array" then . else [] end)[]
+  | select((.type? // "") == "command")
   | select(.command != null and .command != "")
   | "\(.command)\t\($m)"
 ' "$settings")"

--- a/config/scripts/validate-hook-wiring.sh
+++ b/config/scripts/validate-hook-wiring.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Assert every committed hook script has a live matcher wiring in a settings.json.
+#
+# Motivation (claude-workflows #24): committed hook *scripts* in config/hooks/ are
+# inert unless ~/.claude/settings.json wires each one under PreToolUse with a
+# matcher. That wiring used to be untracked, so a committed hook could silently
+# never fire. This checker fails if any hook is unwired or wired with an empty
+# matcher, so the tracked config/settings.json can't drift away from the hooks.
+#
+# It deliberately checks presence + a non-empty matcher only, NOT whether the
+# matcher covers the "right" tools: inferring intended tools from a script is
+# brittle, and tracking settings.json (the sibling change) already makes matcher
+# edits visible in review.
+#
+# Usage: validate-hook-wiring.sh [SETTINGS_JSON] [HOOKS_DIR]
+#   SETTINGS_JSON  defaults to <repo>/config/settings.json
+#   HOOKS_DIR      defaults to <repo>/config/hooks
+# Exit 0 = all hooks wired; 1 = a wiring problem; 2 = usage/dependency error.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+config_dir="$(cd "$here/.." && pwd)"
+
+settings="${1:-$config_dir/settings.json}"
+hooks_dir="${2:-$config_dir/hooks}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: validate-hook-wiring requires 'jq' on PATH." >&2
+  exit 2
+fi
+
+if [ ! -f "$settings" ]; then
+  echo "error: settings file not found: $settings" >&2
+  exit 2
+fi
+
+if [ ! -d "$hooks_dir" ]; then
+  echo "error: hooks dir not found: $hooks_dir" >&2
+  exit 2
+fi
+
+# Map of wired-hook-basename -> non-empty? We collect every PreToolUse command
+# and remember, per basename, whether ANY wiring for it has a non-empty matcher.
+# Format per line: "<basename>\t<matcher>" (matcher may be empty).
+wired="$(jq -r '
+  (.hooks.PreToolUse // [])[]
+  | (.matcher // "") as $m
+  | (.hooks // [])[]
+  | select(.type == "command")
+  | "\(.command)\t\($m)"
+' "$settings")"
+
+problems=0
+
+# Iterate committed hook scripts, skipping test files.
+shopt -s nullglob
+for path in "$hooks_dir"/*.sh; do
+  base="$(basename "$path")"
+  case "$base" in
+    *.test.sh) continue ;;
+  esac
+
+  # Does any wired command share this basename, and does at least one such
+  # wiring carry a non-empty matcher?
+  found=0
+  has_matcher=0
+  while IFS=$'\t' read -r cmd matcher; do
+    [ -n "$cmd" ] || continue
+    if [ "$(basename "$cmd")" = "$base" ]; then
+      found=1
+      [ -n "$matcher" ] && has_matcher=1
+    fi
+  done <<<"$wired"
+
+  if [ "$found" -eq 0 ]; then
+    echo "MISSING wiring: $base is committed but no PreToolUse hook references it in $settings" >&2
+    problems=$((problems+1))
+  elif [ "$has_matcher" -eq 0 ]; then
+    echo "EMPTY matcher: $base is wired but every matcher is empty in $settings (it will never fire)" >&2
+    problems=$((problems+1))
+  else
+    echo "ok: $base wired"
+  fi
+done
+shopt -u nullglob
+
+if [ "$problems" -ne 0 ]; then
+  echo "validate-hook-wiring: $problems problem(s) found." >&2
+  exit 1
+fi
+
+echo "validate-hook-wiring: all hooks wired."
+exit 0

--- a/config/scripts/validate-hook-wiring.sh
+++ b/config/scripts/validate-hook-wiring.sh
@@ -2,18 +2,19 @@
 # Assert every committed hook script has a live matcher wiring in a settings.json.
 #
 # Motivation (claude-workflows #24): committed hook *scripts* in config/hooks/ are
-# inert unless ~/.claude/settings.json wires each one under PreToolUse with a
-# matcher. That wiring used to be untracked, so a committed hook could silently
-# never fire. This checker fails if any hook is unwired or wired with an empty
-# matcher, so the tracked config/settings.json can't drift away from the hooks.
+# inert unless a settings.json wires each one under PreToolUse with a matcher.
+# That wiring is easy to get wrong or let drift, so a committed hook could
+# silently never fire. This checker fails if any hook is unwired or wired with an
+# empty matcher. Run it against the tracked config/settings.example.json (does the
+# template wire everything?) and against the live ~/.claude/settings.json (is your
+# real config still wiring every committed hook?).
 #
 # It deliberately checks presence + a non-empty matcher only, NOT whether the
 # matcher covers the "right" tools: inferring intended tools from a script is
-# brittle, and tracking settings.json (the sibling change) already makes matcher
-# edits visible in review.
+# brittle, and the tracked example makes the intended matchers visible in review.
 #
 # Usage: validate-hook-wiring.sh [SETTINGS_JSON] [HOOKS_DIR]
-#   SETTINGS_JSON  defaults to <repo>/config/settings.json
+#   SETTINGS_JSON  defaults to <repo>/config/settings.example.json
 #   HOOKS_DIR      defaults to <repo>/config/hooks
 # Exit 0 = all hooks wired; 1 = a wiring problem; 2 = usage/dependency error.
 set -euo pipefail
@@ -21,7 +22,7 @@ set -euo pipefail
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 config_dir="$(cd "$here/.." && pwd)"
 
-settings="${1:-$config_dir/settings.json}"
+settings="${1:-$config_dir/settings.example.json}"
 hooks_dir="${2:-$config_dir/hooks}"
 
 if ! command -v jq >/dev/null 2>&1; then
@@ -39,16 +40,34 @@ if [ ! -d "$hooks_dir" ]; then
   exit 2
 fi
 
-# Map of wired-hook-basename -> non-empty? We collect every PreToolUse command
-# and remember, per basename, whether ANY wiring for it has a non-empty matcher.
-# Format per line: "<basename>\t<matcher>" (matcher may be empty).
+# Fail with a clear, script-level message if settings is not valid JSON, rather
+# than letting `set -e` abort on jq's raw parse error further down.
+if ! jq -e . "$settings" >/dev/null 2>&1; then
+  echo "error: settings file is not valid JSON: $settings" >&2
+  exit 2
+fi
+
+# Every PreToolUse command with its matcher, one "<command>\t<matcher>" per line.
+# Skip null/empty commands so a malformed entry can't surface as the string "null".
 wired="$(jq -r '
   (.hooks.PreToolUse // [])[]
   | (.matcher // "") as $m
   | (.hooks // [])[]
   | select(.type == "command")
+  | select(.command != null and .command != "")
   | "\(.command)\t\($m)"
 ' "$settings")"
+
+# Does a wired command string reference hook script $base? Match the basename as a
+# path/word token so a command carrying args ("/x/foo.sh --flag") or a shell
+# prefix ("sh -c '/x/foo.sh'", "bash /x/foo.sh") still counts as wired, without
+# foo.sh spuriously matching inside foobar.sh.
+references_hook() {
+  local cmd="$1" base="$2" esc re
+  esc="${base//./\\.}"
+  re="(^|[/[:space:]'\"])${esc}([[:space:]'\"]|\$)"
+  [[ "$cmd" =~ $re ]]
+}
 
 problems=0
 
@@ -60,13 +79,13 @@ for path in "$hooks_dir"/*.sh; do
     *.test.sh) continue ;;
   esac
 
-  # Does any wired command share this basename, and does at least one such
-  # wiring carry a non-empty matcher?
+  # Does any wired command reference this hook, and does at least one such wiring
+  # carry a non-empty matcher?
   found=0
   has_matcher=0
   while IFS=$'\t' read -r cmd matcher; do
     [ -n "$cmd" ] || continue
-    if [ "$(basename "$cmd")" = "$base" ]; then
+    if references_hook "$cmd" "$base"; then
       found=1
       [ -n "$matcher" ] && has_matcher=1
     fi

--- a/config/scripts/validate-hook-wiring.test.sh
+++ b/config/scripts/validate-hook-wiring.test.sh
@@ -115,6 +115,11 @@ check "command with args / shell prefix wired" 0 "$args_and_shell"
 check "null command entry is skipped"          0 "$null_command"
 check "foobar.sh does not satisfy foo.sh"      1 "$foobar_not_foo"  "foo.sh"
 
+# valid JSON with unexpected types for hooks / PreToolUse must be treated as
+# "no wiring found" (clean rc=1), not crash jq under set -e.
+check "hooks is an array -> clean fail, no jq crash"      1 '{ "hooks": [] }'                        "foo.sh"
+check "PreToolUse is an object -> clean fail"             1 '{ "hooks": { "PreToolUse": {} } }'      "foo.sh"
+
 # missing settings file -> nonzero with a clear error
 out="$(bash "$script" "$work/does-not-exist.json" "$hooks_dir" 2>&1)"; got=$?
 if [ "$got" -ne 0 ] && printf '%s' "$out" | grep -qiF "not found"; then

--- a/config/scripts/validate-hook-wiring.test.sh
+++ b/config/scripts/validate-hook-wiring.test.sh
@@ -13,8 +13,10 @@ repo_root="$(cd "$here/../.." && pwd)"
 pass=0
 fail=0
 
-# fixtures live in a scratch dir so tests never touch the real config/
-work="$(mktemp -d)"
+# fixtures live in a scratch dir so tests never touch the real config/.
+# mktemp -d works without a template on GNU and modern macOS/BSD; the -t fallback
+# keeps older BSD mktemp happy too.
+work="$(mktemp -d 2>/dev/null || mktemp -d -t cc-wiring-test)"
 trap 'rm -rf "$work"' EXIT
 
 hooks_dir="$work/hooks"
@@ -57,6 +59,34 @@ extra_unrelated='{
 
 no_hooks_key='{ "model": "whatever" }'
 
+# foo carries args, bar is invoked through a shell prefix on a different path:
+# both must still be detected as wired (Copilot: basename match must tolerate
+# args and `sh -c` / `bash` prefixes).
+args_and_shell='{
+  "hooks": { "PreToolUse": [
+    { "matcher": "Write", "hooks": [ { "type": "command", "command": "/x/foo.sh --flag arg" } ] },
+    { "matcher": "Bash", "hooks": [ { "type": "command", "command": "bash /deep/path/bar.sh" } ] }
+  ] }
+}'
+
+# a malformed command entry (no command field) must be skipped, not surface as
+# the string "null" or crash the run; real wiring for foo and bar still passes.
+null_command='{
+  "hooks": { "PreToolUse": [
+    { "matcher": "Write", "hooks": [ { "type": "command", "command": "/x/foo.sh" } ] },
+    { "matcher": "Bash", "hooks": [ { "type": "command" } ] },
+    { "matcher": "Bash", "hooks": [ { "type": "command", "command": "/x/bar.sh" } ] }
+  ] }
+}'
+
+# foobar.sh must NOT satisfy foo.sh (no naive substring match); foo.sh is unwired.
+foobar_not_foo='{
+  "hooks": { "PreToolUse": [
+    { "matcher": "Write", "hooks": [ { "type": "command", "command": "/x/foobar.sh" } ] },
+    { "matcher": "Bash", "hooks": [ { "type": "command", "command": "/x/bar.sh" } ] }
+  ] }
+}'
+
 # check <name> <expected_exit> <settings_json> [expected_substring]
 check() {
   local name="$1" want_exit="$2" json="$3" want_sub="${4:-}"
@@ -81,6 +111,9 @@ check "unwired hook -> fail, names it"         1 "$missing_bar"     "bar.sh"
 check "wired but empty matcher -> fail"        1 "$empty_matcher"   "bar.sh"
 check "extra unrelated hooks -> still pass"    0 "$extra_unrelated"
 check "no hooks key at all -> fail"            1 "$no_hooks_key"    "foo.sh"
+check "command with args / shell prefix wired" 0 "$args_and_shell"
+check "null command entry is skipped"          0 "$null_command"
+check "foobar.sh does not satisfy foo.sh"      1 "$foobar_not_foo"  "foo.sh"
 
 # missing settings file -> nonzero with a clear error
 out="$(bash "$script" "$work/does-not-exist.json" "$hooks_dir" 2>&1)"; got=$?
@@ -90,19 +123,28 @@ else
   fail=$((fail+1)); printf 'FAIL missing settings file (exit=%s): %s\n' "$got" "$out"
 fi
 
+# invalid JSON settings -> exit 2 with a clear, script-level message
+sfile="$work/settings.json"; printf '{not json\n' >"$sfile"
+out="$(bash "$script" "$sfile" "$hooks_dir" 2>&1)"; got=$?
+if [ "$got" -eq 2 ] && printf '%s' "$out" | grep -qiF "not valid JSON"; then
+  pass=$((pass+1)); printf 'ok   invalid JSON settings -> error\n'
+else
+  fail=$((fail+1)); printf 'FAIL invalid JSON settings (exit=%s): %s\n' "$got" "$out"
+fi
+
 # .test.sh fixtures must be ignored (foo.test.sh not required to be wired)
 check ".test.sh files are ignored"             0 "$both_wired"
 
-# integration: the repo's real config/settings.json must wire the real hooks
-if [ -f "$repo_root/config/settings.json" ]; then
-  out="$(bash "$script" "$repo_root/config/settings.json" "$repo_root/config/hooks" 2>&1)"; got=$?
+# integration: the repo's real config/settings.example.json must wire the real hooks
+if [ -f "$repo_root/config/settings.example.json" ]; then
+  out="$(bash "$script" "$repo_root/config/settings.example.json" "$repo_root/config/hooks" 2>&1)"; got=$?
   if [ "$got" -eq 0 ]; then
-    pass=$((pass+1)); printf 'ok   real config/settings.json wires real hooks\n'
+    pass=$((pass+1)); printf 'ok   real config/settings.example.json wires real hooks\n'
   else
-    fail=$((fail+1)); printf 'FAIL real config/settings.json (exit=%s): %s\n' "$got" "$out"
+    fail=$((fail+1)); printf 'FAIL real config/settings.example.json (exit=%s): %s\n' "$got" "$out"
   fi
 else
-  printf 'skip real config/settings.json (file not present yet)\n'
+  printf 'skip real config/settings.example.json (file not present yet)\n'
 fi
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"

--- a/config/scripts/validate-hook-wiring.test.sh
+++ b/config/scripts/validate-hook-wiring.test.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Tests for validate-hook-wiring.sh. Plain bash, fixture-driven, zero deps beyond
+# jq (which the script itself requires). Mirrors the block-em-dash.test.sh style:
+# build a payload, run the script, assert on exit code and message.
+#
+# Run: bash config/scripts/validate-hook-wiring.test.sh
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script="$here/validate-hook-wiring.sh"
+repo_root="$(cd "$here/../.." && pwd)"
+
+pass=0
+fail=0
+
+# fixtures live in a scratch dir so tests never touch the real config/
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+hooks_dir="$work/hooks"
+mkdir -p "$hooks_dir"
+# Two real-looking hooks plus a .test.sh that must be ignored by the validator.
+: >"$hooks_dir/foo.sh"
+: >"$hooks_dir/bar.sh"
+: >"$hooks_dir/foo.test.sh"
+
+# write_settings <file> <json>
+write_settings() { printf '%s\n' "$2" >"$1"; }
+
+both_wired='{
+  "hooks": { "PreToolUse": [
+    { "matcher": "Write|Edit", "hooks": [ { "type": "command", "command": "/x/foo.sh" } ] },
+    { "matcher": "Write|Edit|Bash", "hooks": [ { "type": "command", "command": "/x/bar.sh" } ] }
+  ] }
+}'
+
+missing_bar='{
+  "hooks": { "PreToolUse": [
+    { "matcher": "Write|Edit", "hooks": [ { "type": "command", "command": "/x/foo.sh" } ] }
+  ] }
+}'
+
+empty_matcher='{
+  "hooks": { "PreToolUse": [
+    { "matcher": "Write|Edit", "hooks": [ { "type": "command", "command": "/x/foo.sh" } ] },
+    { "matcher": "", "hooks": [ { "type": "command", "command": "/x/bar.sh" } ] }
+  ] }
+}'
+
+extra_unrelated='{
+  "hooks": { "PreToolUse": [
+    { "matcher": "Write|Edit", "hooks": [ { "type": "command", "command": "/x/foo.sh" } ] },
+    { "matcher": "Write|Edit|Bash", "hooks": [ { "type": "command", "command": "/x/bar.sh" } ] },
+    { "matcher": "Read", "hooks": [ { "type": "command", "command": "/x/other.sh" } ] }
+  ] }
+}'
+
+no_hooks_key='{ "model": "whatever" }'
+
+# check <name> <expected_exit> <settings_json> [expected_substring]
+check() {
+  local name="$1" want_exit="$2" json="$3" want_sub="${4:-}"
+  local sfile="$work/settings.json"
+  write_settings "$sfile" "$json"
+  local out ; out="$(bash "$script" "$sfile" "$hooks_dir" 2>&1)"
+  local got=$?
+  local ok=1
+  [ "$got" -eq "$want_exit" ] || ok=0
+  if [ -n "$want_sub" ] && ! printf '%s' "$out" | grep -qF "$want_sub"; then ok=0; fi
+  if [ "$ok" -eq 1 ]; then
+    pass=$((pass+1)); printf 'ok   %s\n' "$name"
+  else
+    fail=$((fail+1))
+    printf 'FAIL %s (exit want=%s got=%s)\n' "$name" "$want_exit" "$got"
+    printf '     output: %s\n' "$out"
+  fi
+}
+
+check "all hooks wired -> pass"                0 "$both_wired"
+check "unwired hook -> fail, names it"         1 "$missing_bar"     "bar.sh"
+check "wired but empty matcher -> fail"        1 "$empty_matcher"   "bar.sh"
+check "extra unrelated hooks -> still pass"    0 "$extra_unrelated"
+check "no hooks key at all -> fail"            1 "$no_hooks_key"    "foo.sh"
+
+# missing settings file -> nonzero with a clear error
+out="$(bash "$script" "$work/does-not-exist.json" "$hooks_dir" 2>&1)"; got=$?
+if [ "$got" -ne 0 ] && printf '%s' "$out" | grep -qiF "not found"; then
+  pass=$((pass+1)); printf 'ok   missing settings file -> error\n'
+else
+  fail=$((fail+1)); printf 'FAIL missing settings file (exit=%s): %s\n' "$got" "$out"
+fi
+
+# .test.sh fixtures must be ignored (foo.test.sh not required to be wired)
+check ".test.sh files are ignored"             0 "$both_wired"
+
+# integration: the repo's real config/settings.json must wire the real hooks
+if [ -f "$repo_root/config/settings.json" ]; then
+  out="$(bash "$script" "$repo_root/config/settings.json" "$repo_root/config/hooks" 2>&1)"; got=$?
+  if [ "$got" -eq 0 ]; then
+    pass=$((pass+1)); printf 'ok   real config/settings.json wires real hooks\n'
+  else
+    fail=$((fail+1)); printf 'FAIL real config/settings.json (exit=%s): %s\n' "$got" "$out"
+  fi
+else
+  printf 'skip real config/settings.json (file not present yet)\n'
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/config/settings.example.json
+++ b/config/settings.example.json
@@ -1,5 +1,4 @@
 {
-  "model": "claude-opus-4-8[1m]",
   "attribution": {
     "commit": "",
     "pr": ""
@@ -26,17 +25,5 @@
         ]
       }
     ]
-  },
-  "enabledPlugins": {},
-  "sandbox": {
-    "enabled": true,
-    "mode": "auto-allow"
-  },
-  "effortLevel": "high",
-  "skipDangerousModePermissionPrompt": true,
-  "theme": "dark",
-  "editorMode": "normal",
-  "autoCompactEnabled": true,
-  "skipAutoPermissionPrompt": true,
-  "tui": "fullscreen"
+  }
 }

--- a/config/settings.json
+++ b/config/settings.json
@@ -1,0 +1,42 @@
+{
+  "model": "claude-opus-4-8[1m]",
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
+  "includeCoAuthoredBy": false,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/block-em-dash.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/block-claude-attribution.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {},
+  "sandbox": {
+    "enabled": true,
+    "mode": "auto-allow"
+  },
+  "effortLevel": "high",
+  "skipDangerousModePermissionPrompt": true,
+  "theme": "dark",
+  "editorMode": "normal",
+  "autoCompactEnabled": true,
+  "skipAutoPermissionPrompt": true,
+  "tui": "fullscreen"
+}


### PR DESCRIPTION
Advances #24 (settings.json drift). Personal posture keys must not reach this public repo, and at user-global scope there is a single settings.json with no private overlay (verified: a user-level settings.local.json is not honored for model/theme/sandbox/skip* keys). So rather than tracking or symlinking the live file, this tracks a template and validates the live file's wiring.

## What this does

- **Tracked template.** `config/settings.example.json` holds only shareable keys: hook wiring (PreToolUse matchers), `includeCoAuthoredBy`, `attribution`. No posture keys.
- **Provisioning.** `config/scripts/install-settings.sh --init` copies the template to the untracked `~/.claude/settings.json` only if absent (never clobbers your private posture keys). `--check` (default, read-only) verifies the live file wires every committed hook and soft-notes when live hooks drift from the template.
- **Wiring validation.** `config/scripts/validate-hook-wiring.sh` fails if any committed `config/hooks/*.sh` is unwired or wired with an empty matcher in a given settings file (run against the tracked template and/or the live file). Presence + non-empty matcher only; matching tolerates command args and shell prefixes.
- Docs in `config/scripts/README.md`; README Hooks section updated to reflect the template.
- Tests: `install-settings.test.sh` (8 cases) and `validate-hook-wiring.test.sh` (14 cases), plain bash, both green. shellcheck clean.

## Approach note (superseded design)

An earlier revision of this PR tracked `config/settings.json` and symlinked it into `~/.claude/`. That was dropped during review: symlinking the whole file into a public repo would publish personal posture keys (`model`, `theme`, `sandbox`, `skip*`), and there is no private user-global overlay to separate public wiring from private posture. The template + live-wiring-validation model keeps posture private while still making hook wiring reviewable and drift-detectable.

## After merge (activation)

Nothing auto-activates on merge; the live `~/.claude/settings.json` is untracked and untouched.

- Fresh machine (no live settings): `bash config/scripts/install-settings.sh --init`, then add your private posture keys (`model`, `theme`, `sandbox`, `skip*`).
- Existing machine (posture keys already present): `bash config/scripts/install-settings.sh --check` to confirm the live file still wires every committed hook. Read-only; no mutation.

## Not in scope
- #67 hook test runner / bats (deferred to a later session).
