### PR TITLE
chore(git): ignore harness-local .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Skills with internal/private references
 skills/slack-plugin-release-post/
+
+# Claude Code harness-local scratch: per-machine settings.local.json, the
+# .cc-writes staging dir, and Claude-managed git worktrees. Never committed.
+.claude/


### PR DESCRIPTION
The `.claude/` directory holds Claude Code harness-local scratch: the per-machine `settings.local.json`, the `.cc-writes` staging dir, and Claude-managed git worktrees (e.g. `.claude/worktrees/`). None of it should ever be committed, but it showed as untracked in every `git status`.

Add `.claude/` to the tracked `.gitignore` so it is ignored for this repo and any clone.

No behavior change; purely repo hygiene.