### PR TITLE
docs(claude): guard against contingent forced-choice questions

### DIFF
--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -7,6 +7,7 @@ Personal defaults applied across all sessions and projects. Local `CLAUDE.md` fi
 - Be extremely concise. Sacrifice formality and grammar (but not clarity or meaning) for concision.
 - No flattery or compliments unless explicitly asked for judgment.
 - When uncertain about intent or direction, ask. Keep asking until ambiguity is fully resolved.
+- When a follow-up question is contingent on a prior answer, either make the questions truly independent, or include an explicit "N/A - depends on the above" option. Never force an answer to a question whose premise a sibling question might invalidate.
 - Don't speculate as if stating fact. When uncertain, say so and frame hypotheses as hypotheses.
 - **No em dashes (U+2014) anywhere, ever.** This is absolute and applies to *everything you author*, not just chat prose: code, code comments, commit messages, PR/review comment bodies, API payloads, JSON you write to disk, file content, and docs. Use a hyphen, comma, semicolon, or parentheses instead. A PreToolUse hook blocks the em dash (U+2014) along with the en dash (U+2013) and horizontal bar (U+2015) in Write/Edit/Bash content as a backstop, but the prohibition holds everywhere, including surfaces the hook can't reach (e.g. MCP tool payloads).
 


### PR DESCRIPTION
Adds a Tone and Behavior rule: when a follow-up question is contingent on a prior answer, make the questions independent or include an explicit "N/A - depends on the above" option; never force an answer to a question whose premise a sibling question might invalidate.

Prompted by a real case where a second AskUserQuestion was premised on the first being answered a particular way, leaving no valid response when it wasn't.