### PR TITLE
chore(rules): track temp-file-path-discipline rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Rules in `config/rules/` are symlinked into `~/.claude/rules/`, making them glob
 - [Memory Hygiene](config/rules/memory-hygiene.md) — guidelines for memory file size, deduplication, and lifecycle
 - [Self-Correction Loop](config/rules/self-correction-loop.md) — on correction, propose a CLAUDE.md or rule update before continuing
 - [Epistemic Honesty](config/rules/epistemic-honesty.md) — label verified vs inferred vs assumed; self-challenge before committing to conclusions
+- [Temp-File Path Discipline](config/rules/temp-file-path-discipline.md) - write and read the same absolute path for file-consuming commands (`--body-file`, `-F`, `@file`); never assume `$TMPDIR` is the scratchpad; verify outward-facing artifacts after creation
 
 ### Hooks
 

--- a/config/rules/temp-file-path-discipline.md
+++ b/config/rules/temp-file-path-discipline.md
@@ -1,0 +1,15 @@
+# Temp-File Path Discipline (for `--body-file`, `-F`, `@file`, config inputs)
+
+Context: I once created a PR whose body was stale content from an unrelated task. Cause: I wrote the body with the Write tool to the scratchpad path, but the `gh pr create` command read `$TMPDIR/pr_body.md`, a different location that happened to hold a leftover file from a prior task. `gh` silently used the stale file (it existed, so no error), and an outward-facing PR shipped with wrong content and wrong issue links.
+
+Rules to never repeat it:
+
+1. **Write and read the exact same absolute path.** When a command consumes a file (`gh ... --body-file`, `curl -d @file`, `-F`, config paths), the path I Write to and the path I pass to the command must be byte-identical. Do not Write to path A and read `$VAR/...` hoping they match.
+
+2. **Do not assume `$TMPDIR` equals the session scratchpad.** They are often different directories. If I want the scratchpad, use the full scratchpad absolute path, not `$TMPDIR/...`.
+
+3. **Use unique, task-specific filenames.** Never reuse a generic name like `pr_body.md` in a shared temp dir; a prior task may have left one there. Include the task/feature and a version suffix (e.g. `ap_ga_pr_body_v2.md`).
+
+4. **Verify outward-facing artifacts after creation.** After creating/editing a PR, issue, or comment from a file, read it back (`gh pr view --json body`) and confirm the content is what I intended before reporting done. This applies to anything published to an external service.
+
+Prefer passing body text inline when the tool allows it, to avoid the file indirection entirely.


### PR DESCRIPTION
Brings the `temp-file-path-discipline` rule under version control per repo convention.

## Problem
Another session authored this rule directly as a plain, untracked file in `~/.claude/rules/`, bypassing the repo's "rules live in `config/rules/`, symlinked into `~/.claude/rules/`" convention. It was live locally but had no source of truth in the repo.

## Fix
- Move the rule content into `config/rules/temp-file-path-discipline.md`.
- Replace the plain `~/.claude/rules/` file with a symlink to the repo copy.
- Add the README Rules entry.

## Rule summary
Guardrails for file-consuming commands (`--body-file`, `-F`, `@file`): write and read the identical absolute path; never assume `$TMPDIR` is the scratchpad; use unique task-specific filenames; verify outward-facing artifacts after creation.