### PR TITLE
docs(claude): guard rule authoring against untracked rules files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,8 @@ When adding a rule to `config/rules/`:
 2. Symlink into `~/.claude/rules/`: `ln -s ~/dev/claude-workflows/config/rules/<name>.md ~/.claude/rules/<name>.md`
 3. Add an entry to the Rules section in `README.md`
 
+**The repo is the single source of truth.** Author the rule in `config/rules/` and reach `~/.claude/rules/` only through the symlink. Never write a rule as a plain file directly in `~/.claude/rules/`; that leaves it live locally but untracked, so it never reaches the repo or peers. This applies even when a self-correction fires mid-task in another project: create the file under `config/rules/` in this repo, then symlink. If you find a plain (non-symlink) rule already sitting in `~/.claude/rules/`, migrate it: move the content into `config/rules/<name>.md`, replace the original with a symlink, and add the README entry (steps 1-3 above).
+
 ## Adding a new skill
 
 When adding a skill to `skills/`:


### PR DESCRIPTION
Strengthens the "Adding a new rule" section of this repo's CLAUDE.md so rules always land in the repo first.

## Why
A session authored the `temp-file-path-discipline` rule as a plain, untracked file directly in `~/.claude/rules/` (see #78). The existing 3-step process was correct but never stated the underlying invariant, so nothing steered against writing straight to `~/.claude/rules/`.

## Change
Adds a callout to the section:
- The repo is the single source of truth; author in `config/rules/` and reach `~/.claude/rules/` only via the symlink.
- Never write a rule as a plain file directly in `~/.claude/rules/` (live locally but untracked, never reaches the repo or peers). Applies even when a self-correction fires mid-task in another project.
- Migration guidance for a plain rule file already found in `~/.claude/rules/`: move content into `config/rules/`, replace with a symlink, add the README entry.

Docs-only.