### PR TITLE
fix(skills): leave reviewer threads open in pr-review

### DIFF
--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -239,12 +239,14 @@ Note: the pull number is required in the path. The comment-level GET endpoint (`
 
 ### Resolving threads after reply
 
-After replying to bot review threads, resolve every thread that received a definitive reply (accepted or rejected). An open thread signals "still needs attention"; a replied-to rejection is definitively addressed and should be resolved too. Timing depends on how the reply was posted:
+**Only resolve threads we authored.** Reply to reviewer and bot threads, then leave them open. Resolution is the thread author's call: leaving it open lets the reviewer see what was flagged and weigh in on the reply. This holds even when the reply is a definitive rejection, and it is the global `CLAUDE.md` "PR Review Conventions" rule.
+
+For our own threads, timing depends on how the reply was posted:
 
 - **Direct reply** (REST `/pulls/{pull_number}/comments/{id}/replies`): reply is immediately published. Resolve right after posting.
 - **Staged as pending review draft** (via `pr-review-batching`): reply is only visible to the author until the user submits the review. Do NOT resolve until after submission. Resolving before publication leaves other reviewers seeing a resolved thread with no visible rationale (worse than silent dismissal).
 
-There is no technical guard; `resolveReviewThread` succeeds regardless of whether a reply exists or is published. The constraint is purely workflow correctness.
+There is no technical guard; `resolveReviewThread` succeeds regardless of who authored the thread or whether a reply is published. The constraint is purely workflow correctness.
 
 Use the GraphQL mutation with the thread's node ID:
 

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -239,14 +239,14 @@ Note: the pull number is required in the path. The comment-level GET endpoint (`
 
 ### Resolving threads after reply
 
-**Only resolve threads we authored.** Reply to reviewer and bot threads, then leave them open. Resolution is the thread author's call: leaving it open lets the reviewer see what was flagged and weigh in on the reply. This holds even when the reply is a definitive rejection, and it is the global `CLAUDE.md` "PR Review Conventions" rule.
+**Only resolve threads we authored.** Reply to reviewer and bot threads, then leave them open. An open thread keeps the flagged concern and our response visible so the reviewer can weigh in; resolving it on their behalf buries the exchange. This holds even when the reply is a definitive rejection. See "PR Review Conventions" in the global `~/.claude/CLAUDE.md` (`config/CLAUDE.md` in the `claude-workflows` repo).
 
 For our own threads, timing depends on how the reply was posted:
 
 - **Direct reply** (REST `/pulls/{pull_number}/comments/{id}/replies`): reply is immediately published. Resolve right after posting.
 - **Staged as pending review draft** (via `pr-review-batching`): reply is only visible to the author until the user submits the review. Do NOT resolve until after submission. Resolving before publication leaves other reviewers seeing a resolved thread with no visible rationale (worse than silent dismissal).
 
-There is no technical guard; `resolveReviewThread` succeeds regardless of who authored the thread or whether a reply is published. The constraint is purely workflow correctness.
+There is no technical guard: `resolveReviewThread` checks neither who authored the thread nor whether a reply exists or has been published. It can still fail for other reasons, such as insufficient permissions, but nothing in the API enforces the workflow above. The constraint is purely workflow correctness.
 
 Use the GraphQL mutation with the thread's node ID:
 


### PR DESCRIPTION
## What

`pr-review` Step 6 ("Resolving threads after reply") instructed resolving *every* thread that received a definitive reply, bot and reviewer threads included. The global `CLAUDE.md` "PR Review Conventions" say the opposite: only resolve threads we authored, so reviewers can see what was flagged and weigh in on the reply.

This aligns the skill with the convention. The pending-review timing rule (direct reply publishes immediately vs. staged draft waits for submission) is preserved but now scoped to our own threads.

## Why now

Surfaced while designing the sub-skills for #69. Both new skills have to cite this convention, so the contradiction needed settling before they reference it. `agents/pr-code-reviewer.md:53` already stated the rule correctly, so `pr-review` was the sole outlier; `review-thorough` and `pr-review-batching` carry no resolution guidance and need no change.

## Validation

Repo has no markdown lint tooling configured. Verified manually: no tables touched (MD060 n/a), no em/en dashes or horizontal bars introduced, section structure and surrounding code blocks unchanged, and cross-checked the other three PR-related files for the same conflict.

Refs #69