### PR TITLE
feat(skills): add Matt Pocock's writing-for-agents skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,24 @@ When adding a rule to `config/rules/`:
 
 When adding a skill to `skills/`:
 
-1. Create `skills/<name>/SKILL.md` with `user-invocable: true` in frontmatter
-2. Symlink into `~/.claude/skills/`: `ln -s ~/dev/claude-workflows/skills/<name> ~/.claude/skills/<name>`
-3. Add an entry to the Skills section in `README.md`
+1. Create `skills/<name>/SKILL.md` with `name` and `description` in frontmatter
+2. Decide invocation (see below) and set `disable-model-invocation` accordingly
+3. Symlink into `~/.claude/skills/`: `ln -s ~/dev/claude-workflows/skills/<name> ~/.claude/skills/<name>`
+4. Add an entry to the Skills section in `README.md`
+
+### Choosing invocation
+
+`disable-model-invocation` is the field that matters. `user-invocable` defaults to `true` and only controls `/` menu visibility, so writing `user-invocable: true` is a no-op; set `user-invocable: false` only to hide a skill from the menu while leaving Claude able to load it.
+
+| Frontmatter | You can `/invoke` | Claude can auto-fire | Context cost |
+| --- | --- | --- | --- |
+| `description` only (default) | Yes | Yes | Description always loaded |
+| `disable-model-invocation: true` | Yes | No | Removed from Claude's context entirely |
+| `user-invocable: false` | No | Yes | Description always loaded |
+
+Default to leaving model invocation on. Set `disable-model-invocation: true` when the skill has side effects you want to time yourself, or when it is expensive and should never fire uninvited. Keep it off when Claude should reach the skill on its own, when another skill invokes it by name, or when it should preload into subagents; a model-invoked skill is still `/`-invocable, so a description only ever adds reach.
+
+Write the `description` for whichever audience can see it: model-facing with trigger branches when Claude can fire it, a plain human-facing one-liner when it cannot.
 
 ## Adding a new agent
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Changes to a skill file in the repo are immediately live — no copy or sync ste
 - [`/codebase-design`](skills/codebase-design/SKILL.md) - shared deep-module vocabulary (module, interface, depth, seam, adapter, leverage, locality) plus deepening and design-it-twice guides; underpins `/improve-codebase-architecture`
 - [`/domain-modeling`](skills/domain-modeling/SKILL.md) - build and sharpen a project's domain model (`CONTEXT.md` glossary, `docs/adr/` decisions); companion to `/improve-codebase-architecture`
 - [`/grilling`](skills/grilling/SKILL.md) - Matt Pocock's decision-tree grilling loop, kept distinct from the customized `/grill-me` so `/improve-codebase-architecture` can call it by name
+- [`/writing-for-agents`](skills/writing-for-agents/SKILL.md) - Matt Pocock's reference for writing any document an agent consumes (skills, `AGENTS.md`, `CLAUDE.md`): context pointers, the two loads, information hierarchy, leading words, pruning. Copied verbatim from [mattpocock/skills](https://github.com/mattpocock/skills/tree/main/skills/productivity/writing-for-agents); model-invoked, so it fires on its own when you edit a skill or `CLAUDE.md`
 
 ### Rules
 

--- a/skills/writing-for-agents/SKILL-MECHANICS.md
+++ b/skills/writing-for-agents/SKILL-MECHANICS.md
@@ -1,0 +1,22 @@
+# Skill mechanics
+
+The skill-specific branch of [`writing-for-agents`](SKILL.md): what changes when the document is a skill — frontmatter, the invocation choice, and router skills. Everything else about writing it is the universal reference in `SKILL.md`.
+
+## Invocation
+
+Two choices, trading the two loads:
+
+- A **model-invoked** skill keeps a `description`, so the agent can fire it autonomously — and other skills can reach it. You can still type its name: model-invocation always _includes_ user reach; a description only ever adds agent discovery, never removes the human's. The description is the skill's top-level context pointer, forced to stay loaded at all times — permanent context load in exchange for discoverability. A model-invoked skill whose content is all reference is also one home for shared reference: another skill can invoke it, so reference needed by several skills lives in one place. Mechanics: omit `disable-model-invocation`, and write a model-facing description carrying the trigger branches (the pointer-writing rules in `SKILL.md` apply in full).
+- A **user-invoked** skill strips the description from the agent's reach: only the human typing its name can invoke it, and no other skill can. Zero context load, but it spends cognitive load — you are the index that must remember it exists. Mechanics: set `disable-model-invocation: true`; the `description` becomes human-facing — a one-line summary, trigger lists stripped.
+
+Pick model-invocation only when the agent must reach the skill on its own, or another skill must. If it only ever fires by hand, make it user-invoked and pay no context load.
+
+Shared reference that two user-invoked skills both need can live in neither — with no descriptions, neither can fire the other. Push it to a plain file outside the skill system: external reference any skill can point at.
+
+## Splitting by invocation
+
+The invocation cut of splitting (the sequence cut lives in `SKILL.md`): split off a model-invoked skill when you have a distinct leading word that should trigger it on its own — a trigger word you actually use in your prompts — or another skill must reach it. You pay context load for the new always-loaded description, so that independent reach has to be worth it.
+
+## Router skills
+
+When user-invoked skills multiply past what you can remember, that piled-up cognitive load is cured by a **router skill**: one user-invoked skill that names the others and when to reach for each, so the human has one skill to remember instead of many. It can only hint, never fire them: user-invoked skills have no description, so nothing but the human can reach them.

--- a/skills/writing-for-agents/SKILL.md
+++ b/skills/writing-for-agents/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: writing-for-agents
+description: Writing documents for agents. Use when creating or editing skills, or modifying AGENTS.md or CLAUDE.md.
+---
+
+<!-- Copied verbatim from Matt Pocock's writing-for-agents skill (MIT licensed), upstream commit 4aaccb5: -->
+<!-- https://github.com/mattpocock/skills/tree/main/skills/productivity/writing-for-agents -->
+<!-- This attribution block is the only local change; SKILL-MECHANICS.md and agents/openai.yaml are byte-identical to upstream. -->
+
+Reference for writing any document an agent consumes — a skill, an `AGENTS.md` / `CLAUDE.md`, a doc reached by a pointer. The packaging differs; the writing does not: the same levers make each one predictable — the agent taking the same _process_ every run, not producing the same output.
+
+When the document you're writing is a skill, read [`SKILL-MECHANICS.md`](SKILL-MECHANICS.md) for frontmatter, invocation choice, and router skills.
+
+## Context pointers
+
+A **context pointer** is a reference held in the agent's context that names some out-of-context material and encodes the condition for reaching it. A skill's description is one; a line in `AGENTS.md` naming a doc is the same object. The pointer's _wording_, not its target, decides when the agent reaches the material — and how reliably. A must-have target behind a weakly worded pointer is a variance bug: sharpen the wording first, and inline the material only if sharpening fails.
+
+A pointer does two jobs — state what the material is, and list the **branches** that should trigger reaching it (a branch is a distinct case the document handles, so different runs take different paths through it). Every word of an always-loaded pointer costs on every turn, so it earns even harder pruning than the body:
+
+- **Front-load the leading word** — the pointer is where it does its triggering work.
+- **One trigger per branch.** Synonyms that rename a single branch are one branch written twice; collapse them and keep only genuinely distinct branches.
+- **Cut identity the body already carries.**
+
+## The two loads
+
+Every document and pointer you add spends one of two budgets:
+
+- **Context load** — the cost of always-loaded material on the agent's window: an `AGENTS.md` line, a skill description, anything sitting in context every turn, spending tokens and attention whether or not it fires.
+- **Cognitive load** — the cost on the human: which documents exist and when to reach for each. The human is the index. Not a cost to minimise — it is the price of human agency; spend it where human judgement matters, remove it where it does not.
+
+Material reached only through a pointer escapes context load at the price of the pointer's own line; material with no pointer at all rides entirely on cognitive load.
+
+## Information hierarchy
+
+A document is built from two content types — **steps** (the ordered actions the agent performs) and **reference** (definitions, rules, facts consulted on demand) — that mix freely: all steps (a recipe), all reference (a review's rules, this skill), or both. The core decision is where each piece sits on the **information hierarchy**, a ladder ranked by how immediately the agent needs the material:
+
+1. **In-file step** — the primary tier: what the agent does, in order.
+2. **In-file reference** — consulted on demand. Often a legitimately flat peer-set (every rule of a review on one rung) — a fine arrangement, not a smell.
+3. **Disclosed reference** — pushed out into a separate file, reached by a context pointer, loaded only when the pointer fires. Spans a sibling file in the same folder through fully external reference that lives anywhere and any document can point at.
+
+Push too little down and the top bloats; push too much and you hide material the agent actually needs. That tension is the whole decision.
+
+**Progressive disclosure** is the move down the ladder — out of the main file and behind a pointer — so the top stays legible. Not primarily a token optimisation: it is how the hierarchy is protected. Branching is the cleanest disclosure test: inline what every branch needs, and push behind a pointer what only some branches reach. When a document has steps, in-file reference that should be disclosed buries them and turns attending to them into a coin-flip — a variance lever, not just a legibility one.
+
+**Co-location** is the within-file companion: where the ladder decides _how far down_ a piece sits, co-location decides _what sits beside it_ once there. Keep a concept's definition, rules, and caveats under one heading rather than scattered, so reading one part brings its neighbours with it. The test: the document should read like documentation written for the agent — grouped material reads that way; scattered material does not. (Distinct from duplication: that repeats one meaning in two places; scattering fragments one meaning across many.)
+
+**Sprawl** is the failure mode here: a document simply too long, even when every line is live and unique. Attention thins across the excess, and every extra line is one more to keep relevant. The cure is the ladder: disclose reference behind pointers, and split by branch or sequence so each path carries only what it needs.
+
+## Steps and completion criteria
+
+Every step ends on a **completion criterion** — the condition that tells the agent the work is done. Two properties make it a lever:
+
+- **Clarity** — can the agent tell done from not-done? A vague bound ("understanding reached") invites **premature completion**: ending the step before it is genuinely done, attention slipping to _being done_. The visible steps still ahead — the **post-completion steps** — supply the pull; the criterion's clarity is the resistance. Defend in order: **sharpen the bound first** (local and cheap); only if it is irreducibly fuzzy _and_ you observe the rush, hide the later steps by splitting the sequence — and hiding only works across a real context boundary (a hand-off or a subagent dispatch; an inline call leaves the later steps in context and clears nothing).
+- **Demand** — how much it requires. "Every modified model accounted for" forces thorough work where "produce a change list" does not. Demand drives **legwork** — the digging the agent does within the work, latent in the wording rather than written as its own step — and it is not step-bound: "every rule applied" binds a body of flat reference just as "every step done" binds a sequence, which is how an all-reference document still carries an exhaustiveness bar.
+
+The strongest criteria are both checkable and exhaustive.
+
+## When to split
+
+Splitting one document into two spends one of the two loads, so split only when the cut earns it:
+
+- **By sequence** — split a run of steps where the post-completion steps tempt the agent to rush the one in front of it. Keeping them out of view drives more legwork on the current task. Beware the reverse: merging sequences exposes each step's later steps to what follows, inviting premature completion.
+- **By invocation** — skill-specific: see [`SKILL-MECHANICS.md`](SKILL-MECHANICS.md).
+
+## Leading words
+
+A **leading word** is a compact concept already living in the model's pretraining that the agent thinks with while running the document (_lesson_, _fog of war_, _tracer bullets_). Repeated as a token, never as a sentence, it accumulates a distributed definition and anchors a whole region of behaviour in the fewest tokens, by recruiting priors the model already holds. Coining your own works if you define it clearly, but a made-up word recruits no priors — you pay in definition tokens what a pretrained word gives free; reach for an existing word first.
+
+It anchors twice. In the body, _execution_: the agent reaches for the same behaviour every time the word appears, and inside flat reference it focuses attention on a class of thing to look for. In a pointer, _invocation_: when the same word lives in your prompts, your docs, and your codebase, the agent links that shared language to the material and reaches it more reliably.
+
+Hunt for opportunities to refactor with leading words. A triad spelled out at three sites, a pointer spending a sentence to gesture at one idea — each is a passage begging to collapse into a single token:
+
+- "fast, deterministic, low-overhead" → _tight_ (a _tight_ loop).
+- "a loop you believe in" → _red_ — a fuzzy gate becomes a binary observable state (the loop goes _red_ on the bug, or it doesn't).
+
+You win twice: fewer tokens, and a sharper hook for the agent to hang its thinking on. Assume every document is carrying restatements that leading words retire — go find them.
+
+**Negation** is the failure mode beside this lever: steering by prohibition drags the forbidden behaviour into context and makes it _more_ available, not less. _Don't think of an elephant_, and the elephant is all there is; the negation is a weak modifier the strongly-activated concept overruns, so the ban half-reads as an instruction to do the thing. Prompt the **positive** — state the target behaviour ("write one-line comments") so the banned one is never spoken. A prohibition earns its place only as a hard guardrail you cannot phrase positively; even then, pair it with the positive target so attention lands on what to do.
+
+## Pruning
+
+- Keep each meaning in a **single source of truth**: one authoritative place, so changing the behaviour is a one-place edit. **Duplication** — the same meaning in more than one place — costs maintenance and tokens, and inflates a meaning's prominence on the ladder past its real rank. (The accidental inverse of a leading word, which repeats a token on purpose, never the meaning.)
+- The **environment** is a source of truth too — `package.json` scripts, config files, the directory layout, `--help` output — and a document that restates it is a **cache**: a copy of a lookup, earning its load only when the lookup is expensive. Cache what the agent cannot find by looking: the unwritten convention, the reason behind a choice, the gotcha no config confesses. Leave the one-file, one-command lookups to the environment, where they cannot go stale.
+- Check every line for **relevance**: does it still bear on what the document does? A line loses relevance by never bearing on the task (mere exposition, or a branch that should be disclosed) or by going stale as the behaviour or world it describes changes. Shorter documents are easier to keep relevant. Without a pruning discipline the default fate is **sediment**: stale layers that settle because adding feels safe and removing feels risky, until you must core down through them to find what is still live.
+- Hunt **no-ops** sentence by sentence: an instruction the model already obeys by default pays load to say nothing. The test — does it change behaviour versus the default? — is model-relative, not reader-relative: two people disagreeing about a no-op disagree about the default, and settle it by running the document, not by debate. When a sentence fails, delete the whole sentence rather than trim words from it. The test also grades leading words: a word too weak to beat the default (_be thorough_ when the agent is already thorough-ish) is a no-op, and the fix is a stronger word (_relentless_), not a different technique.

--- a/skills/writing-for-agents/agents/openai.yaml
+++ b/skills/writing-for-agents/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Writing for Agents"
+  short_description: "Write documents agents consume"


### PR DESCRIPTION
Adds Matt Pocock's `writing-for-agents` skill, copied verbatim from [mattpocock/skills](https://github.com/mattpocock/skills/tree/main/skills/productivity/writing-for-agents) (MIT licensed) at upstream commit `4aaccb5`.

The skill is a reference for writing any document an agent consumes (a skill, an `AGENTS.md` / `CLAUDE.md`, a doc reached by a pointer): context pointers, context vs. cognitive load, the information hierarchy and progressive disclosure, completion criteria, when to split, leading words, and pruning. `SKILL-MECHANICS.md` covers the skill-specific branch: frontmatter, invocation choice, router skills.

## What's here

| File | Notes |
| --- | --- |
| `skills/writing-for-agents/SKILL.md` | Verbatim upstream plus a three-line attribution comment below the frontmatter |
| `skills/writing-for-agents/SKILL-MECHANICS.md` | Byte-identical to upstream |
| `skills/writing-for-agents/agents/openai.yaml` | Byte-identical to upstream |
| `README.md` | Entry added to the Skills section |
| `CLAUDE.md` | Corrects the skill invocation convention (see below) |

Verified with a diff against a fresh fetch of upstream at the pinned SHA: the attribution block is the only delta.

## The CLAUDE.md correction

Reviewing this skill's invocation surfaced that our own convention was inert. "Adding a new skill" told authors to set `user-invocable: true`, but per the [skills docs](https://code.claude.com/docs/en/skills) that is the default and only controls `/` menu visibility: "The `user-invocable` field only controls menu visibility, not Skill tool access." It never affected model invocation.

`disable-model-invocation` is the field that actually decides, and exactly one skill in the repo sets it (`improve-codebase-architecture`). The other 16 carrying `user-invocable: true` are all model-invoked with always-loaded descriptions.

Confirmed empirically as well as from docs: `improve-codebase-architecture` has a working symlink and is absent from the model-facing skill listing, while every `user-invocable: true` skill appears there with its full description.

So `CLAUDE.md` now names `disable-model-invocation`, tabulates the three meaningful states with their context cost, and says when to turn model invocation off.

Stripping the inert field from the 16 skills that carry it, and reviewing each skill's invocation on the merits, is deliberately out of scope here and tracked in #84.

## Things to know

- **This skill is model-invoked, matching 16 of the repo's 17 other skills.** It fires on its own when a skill, `AGENTS.md`, or `CLAUDE.md` is being edited, which is the intended behavior and is what upstream ships. Worth keeping: in a repo that is mostly skills and rule files nearly every edit is a trigger, and the failure mode of manual invocation is not thinking to type `/writing-for-agents` at the moment you are writing a description badly. The always-loaded cost is one description line; the ~11KB body only loads when it fires. The skill's own `SKILL-MECHANICS.md` argues the same: pick model-invocation "when the agent must reach the skill on its own, or another skill must."
- **Upstream prose uses em dashes**, contrary to the global `CLAUDE.md` rule. That rule governs what we author; this is a third-party verbatim copy, so the characters were left untouched.
- **The `~/.claude/skills/writing-for-agents` symlink is created but dangles until this merges.** It points at `~/dev/claude-workflows/skills/writing-for-agents/`, which resolves against the main checkout, not the worktree this was developed in. It goes live once main is updated.
