### PR TITLE
chore: generalize identifiable references

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,4 @@ Subagent definitions in `agents/` are symlinked into `~/.claude/agents/`, making
 
 ### Skills
 
-- **Evaluate replacing `/pr-review` with Cowork's `/review`** — our custom skill had a repo-resolution bug (given a grafana-adaptivelogs-app PR, it cloned and worked in adaptivetraces-app, took many turns to self-correct). Cowork's built-in `/review` may handle repo context better. However, the two skills surfaced different feedback, so the right move is likely to consolidate the best of both rather than a straight swap.
+- **Evaluate replacing `/pr-review` with Cowork's `/review`** — our custom skill had a repo-resolution bug (given a PR in one repo, it cloned and worked in a similarly-named sibling repo, took many turns to self-correct). Cowork's built-in `/review` may handle repo context better. However, the two skills surfaced different feedback, so the right move is likely to consolidate the best of both rather than a straight swap.

--- a/internals/memory-context-management.md
+++ b/internals/memory-context-management.md
@@ -51,7 +51,7 @@ They're the only thing Claude sees before deciding to read or skip. Quality here
 | --- | --- |
 | "project context notes" | "React 19 upgrade plan for issue #607, PR #652" |
 | "testing feedback" | "Integration tests must hit real DB, not mocks — prior prod incident" |
-| "CSS findings" | "Grafana Collapse DOM structure and Emotion cx() override strategies for #474" |
+| "CSS findings" | "Collapse component DOM structure and Emotion cx() override strategies for a given issue" |
 
 ### File sizing
 

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -380,12 +380,11 @@ taking any action that changes PR state.
 
 ## Notes
 
-- **Repos you may encounter** include Grafana plugin repos (`grafana-adaptivelogs-app`,
-  `grafana-adaptiveprofiles-app`, `gex-plugins`). These are TypeScript/React frontends with Go
-  backends, using `react-hook-form`, RTK Query / react-query, Grafana plugin SDK conventions, and
-  `gh` CLI for CI.
+- **Repos you may encounter** are often observability-platform plugins: TypeScript/React frontends
+  with Go backends, using `react-hook-form`, RTK Query / react-query, host-platform plugin SDK
+  conventions, and `gh` CLI for CI.
 - **Language-specific defaults**: For TypeScript/React, check prop contract changes and hook
   dependency arrays. For Go, check error wrapping patterns and goroutine safety. For YAML workflows,
   check token scopes and trigger conditions.
-- **Multi-repo PRs**: Grafana plugin PRs often have companion PRs in `profiles-drilldown` or other
-  repos. Look for references in the PR description and flag any unresolved cross-repo dependencies.
+- **Multi-repo PRs**: plugin PRs often have companion PRs in sibling repos. Look for references in
+  the PR description and flag any unresolved cross-repo dependencies.


### PR DESCRIPTION
This repo is public. Three merged files named specific employer repos, which together read as a
public list of what I work on. This generalizes them without losing the guidance.

| File | Was | Now |
| --- | --- | --- |
| `skills/pr-review/SKILL.md` | Named three plugin repos plus a companion repo | Describes the stack ("observability-platform plugins: TypeScript/React frontends with Go backends") and "sibling repos" |
| `README.md` | Repo-resolution bug anecdote named both repos involved | "given a PR in one repo, it cloned and worked in a similarly-named sibling repo" |
| `internals/memory-context-management.md` | Memory-description example named a component library and an issue number | Generic component and "a given issue" |

In every case the names were incidental. The `pr-review` guidance was never repo-specific, and the
README anecdote's point is that similarly-named siblings get confused, which survives the edit.

## Left alone deliberately

`skills/check-npm/SKILL.md` cites the public `grafana` GitHub org as a git-dependency allow-list
convention. That org is public, no internal repo is named, and the example loses its point without a
concrete org. Flagging it here rather than silently including it, so the call is visible.

## Related

Issue #69, PR #82 and their comments were scrubbed separately, and #82's branch history was rewritten
to drop the same references from a commit message before it lands.
