### PR TITLE
feat(skills): add pr-review-bot-loop

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,12 +7,18 @@ name: tests
 on:
   pull_request:
     paths:
-      - 'skills/**/*.py'
+      # Matches exactly what the run step discovers. A broader trigger would
+      # give a future skill's script a green run that tested nothing, which
+      # reads as coverage; add that skill's directory here instead.
+      - 'skills/pr-review-bot-loop/scripts/**'
       - '.github/workflows/tests.yml'
   push:
     branches: [main]
     paths:
-      - 'skills/**/*.py'
+      # Matches exactly what the run step discovers. A broader trigger would
+      # give a future skill's script a green run that tested nothing, which
+      # reads as coverage; add that skill's directory here instead.
+      - 'skills/pr-review-bot-loop/scripts/**'
       - '.github/workflows/tests.yml'
   workflow_dispatch:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: tests
+
+# The repo is mostly prose. This runs the one thing in it that is executable
+# logic: the pr-review-bot-loop detector, whose exit codes decide whether a
+# review loop terminates.
+
+on:
+  pull_request:
+    paths:
+      - 'skills/**/*.py'
+      - '.github/workflows/tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'skills/**/*.py'
+      - '.github/workflows/tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Floor is the macOS system interpreter the scripts are developed
+        # against; ceiling guards against stdlib drift on newer runners.
+        python-version: ['3.9', '3.13']
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      # Offline cases only. The SIGNALS_LIVE half asserts against real PRs
+      # through the API, which is a pre-push check rather than a CI gate.
+      - run: python3 -m unittest discover -s skills/pr-review-bot-loop/scripts -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,9 @@
 name: tests
 
-# The repo is mostly prose. This runs the one thing in it that is executable
-# logic: the pr-review-bot-loop detector, whose exit codes decide whether a
-# review loop terminates.
+# Runs the pr-review-bot-loop detector's tests, whose exit codes decide whether
+# a review loop terminates. Other executable logic in the repo is not covered
+# here: config/hooks/ has its own test script (block-em-dash.test.sh) that
+# nothing runs automatically, and work-next-task/scripts/ralph.sh has no tests.
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ agents/        Subagent definitions, symlinked into ~/.claude/agents/
 
 The repo is mostly prose, so there is no build. The one exception is
 `skills/pr-review-bot-loop/scripts/`, whose detector decides whether a review loop terminates and
-is covered by tests that CI runs on any PR touching `skills/**/*.py`:
+is covered by tests that CI runs on any PR touching that directory:
 
 ```bash
 python3 -m unittest discover -s skills/pr-review-bot-loop/scripts        # offline, what CI runs

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ skills/        Skill drafts before deploying to ~/.claude/skills/
 agents/        Subagent definitions, symlinked into ~/.claude/agents/
 ```
 
-The repo is mostly prose, so there is no build. The one exception is
-`skills/pr-review-bot-loop/scripts/`, whose detector decides whether a review loop terminates and
-is covered by tests that CI runs on any PR touching that directory:
+The repo is mostly prose and has no build. It does carry some executable logic: the hook scripts in
+`config/hooks/`, `skills/work-next-task/scripts/ralph.sh`, and the bot-loop detector. Only the
+detector has automated tests, and CI runs them on any PR touching its directory:
 
 ```bash
 python3 -m unittest discover -s skills/pr-review-bot-loop/scripts        # offline, what CI runs

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Changes to a skill file in the repo are immediately live — no copy or sync ste
 - [`/pr-review`](skills/pr-review/SKILL.md) — AI-assisted GitHub PR review with line-level draft comments
 - [`/pr-review-batching`](skills/pr-review-batching/SKILL.md) - stage PR review comments as drafts on a pending review (never publishes); owns ensure-then-append and accidental-publish incident response
 - [`/pr-review-adversarial`](skills/pr-review-adversarial/SKILL.md) - two-phase adversarial validation of review findings: an independent fresh-context reviewer attacks the code, then a second reviewer attacks every finding, fix, and dismissal with a default-to-NOT-PROVEN mandate
+- [`/pr-review-bot-loop`](skills/pr-review-bot-loop/SKILL.md) - drive your own PR to a clean automated-reviewer pass before human review: a five-signal Copilot adapter (re-request / pending? / landed? / clean? / suppressed?) whose `suppressed?` signal catches the real findings Copilot hides in the review body. Ships with `scripts/copilot-signals.py`
 - [`/memory-audit`](skills/memory-audit/SKILL.md) — reflective review, consolidation, and pruning of memory files; defaults to current project, offers a cross-project sweep for promotion candidates
 - [`/branch-cleanup`](skills/branch-cleanup/SKILL.md) — interactive local branch cleanup with PR cross-referencing
 - [`/grill-me`](skills/grill-me/SKILL.md) — stress-test a plan or design through relentless interrogation

--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ skills/        Skill drafts before deploying to ~/.claude/skills/
 agents/        Subagent definitions, symlinked into ~/.claude/agents/
 ```
 
+The repo is mostly prose, so there is no build. The one exception is
+`skills/pr-review-bot-loop/scripts/`, whose detector decides whether a review loop terminates and
+is covered by tests that CI runs on any PR touching `skills/**/*.py`:
+
+```bash
+python3 -m unittest discover -s skills/pr-review-bot-loop/scripts        # offline, what CI runs
+SIGNALS_LIVE=1 python3 -m unittest discover -s skills/pr-review-bot-loop/scripts
+```
+
+The live half asserts against real PRs through the GitHub API, so it needs an authenticated `gh`
+and stays a pre-push check rather than a CI gate.
+
 ## Contents
 
 ### Internals

--- a/skills/pr-review-bot-loop/SKILL.md
+++ b/skills/pr-review-bot-loop/SKILL.md
@@ -83,8 +83,12 @@ all measured, and guessing the equivalents for another bot reproduces none of th
 `landed?` and `suppressed?` ship as a script, since between them they carry every measured trap:
 
 ```bash
-skills/pr-review-bot-loop/scripts/copilot-signals.py <owner> <repo> <pr-number>
+~/.claude/skills/pr-review-bot-loop/scripts/copilot-signals.py <owner> <repo> <pr-number>
 ```
+
+That is the installed path, and it is the one to use: the loop runs from the target project's
+working directory, which is usually not this repo. The repo-relative paths further down are
+deliberate, and they apply only when you are editing the detector itself.
 
 Exit `0` clean, `1` triage-required, `2` not-applicable, `3` error. It prints the pending request,
 every Copilot review with its commit, inline count, and suppressed findings. Exit `3` is a signal
@@ -139,7 +143,7 @@ It is three-state. Collapsing it to a boolean is a bug in opposite directions.
 | State | Condition | Loop action |
 | --- | --- | --- |
 | clean | review at head, nothing posted and nothing suppressed | terminate |
-| triage-required | review at head, suppressed count non-zero or unparsable | read the block, triage, fix, push, re-request |
+| triage-required | review at head, and any of: inline comments non-zero, suppressed count non-zero or unparsable, or parsed findings disagreeing with a declared count | triage whatever it reported, posted or withheld, then fix, push, re-request |
 | not-applicable | no review at head | re-request, or wait if one is pending |
 
 - **Scope the check to the review at `headRefOid`.** A detector that scans every review on the PR
@@ -182,10 +186,18 @@ Each round:
 
 1. **Read the signals.** Run `copilot-signals.py` and branch on its exit status: `0` go to
    Termination, `1` triage, `2` re-request or wait, `3` fix the query and re-run.
-2. **Re-request only when both hold**: a new commit is at head, and nothing is pending against it.
-   A request already in flight means wait, not re-request.
-3. **Wait** with `ScheduleWakeup` at `poll`. Poll the signals again; do not conclude anything from
-   the wait itself.
+
+   On `1`, triage only the findings at this head that are **not already dispositioned**. If every
+   one of them is, go to Termination. Exit `1` is computed from what the review says, not from what
+   you did about it, so declining a finding leaves it at `1` forever; without this clause the loop
+   re-triages the same findings until `max_rounds`.
+2. **Re-request when no review exists at head and nothing is pending against it.** A request already
+   in flight means wait, not re-request; that gate is what keeps you off the double-request trap.
+   Head-scoping already encodes "the current commit is unreviewed", so there is no separate
+   new-commit condition to check, and the entry case of a PR the bot has never seen qualifies.
+3. **Wait** before polling again. Under `/loop` dynamic mode, use `ScheduleWakeup` at `poll`.
+   Otherwise run the poll as a background shell command; foreground `sleep` is blocked in this
+   harness. Conclude nothing from the wait itself.
 4. **Triage every finding, posted and suppressed together.** Route them through
    `/pr-review-adversarial` Phase 2 rather than acting on them directly. Low-confidence items are
    exactly where a refuter earns its cost: of 7 suppressed issues on the measured PR, 2 rested on
@@ -197,7 +209,11 @@ Each round:
 7. **Reply to the threads** you acted on, then loop.
 
 A push moves head, which makes the next signal read `not-applicable` and sends you to step 2. The
-detector drives the loop; you do not track round state separately.
+detector drives the loop; you do not track round state separately. The one thing it cannot tell you
+is whether you already dispositioned a finding, so record that where the detector's own inputs live:
+a published `:zap:` or `:thought_balloon:` reply on the thread, and for a suppressed finding, which
+has no thread, the commit message that fixed it or a PR comment declining it. Disposition then lives
+on the PR rather than in session memory, and a fresh session picks the loop up mid-flight.
 
 ### Thread hygiene
 

--- a/skills/pr-review-bot-loop/SKILL.md
+++ b/skills/pr-review-bot-loop/SKILL.md
@@ -185,7 +185,14 @@ SIGNALS_LIVE=1 python3 -m unittest discover -s skills/pr-review-bot-loop/scripts
 Each round:
 
 1. **Read the signals.** Run `copilot-signals.py` and branch on its exit status: `0` go to
-   Termination, `1` triage, `2` re-request or wait, `3` fix the query and re-run.
+   Termination, `1` triage, `2` re-request or wait, `3` no verdict.
+
+   Exit `3` covers two different things and they need different responses. A transient failure (TLS
+   handshake timeout, rate limit, a 5xx) is retried on the next poll and costs nothing; observed
+   once against a corporate proxy during a live run. A structural one (a bad argument, a moved
+   schema, a repo you cannot read) repeats every poll, so treat a `3` that survives two consecutive
+   polls as a defect to fix rather than as weather. Either way it is not a verdict, so never
+   substitute one of the other three for it.
 
    On `1`, triage only the findings at this head that are **not already dispositioned**. If every
    one of them is, go to Termination. Exit `1` is computed from what the review says, not from what

--- a/skills/pr-review-bot-loop/SKILL.md
+++ b/skills/pr-review-bot-loop/SKILL.md
@@ -165,6 +165,15 @@ known, never by review, and each surfaced only after the previous one was fixed.
 cannot find them: the head-scoping trap appears only once a fix has landed. A detector validated
 only against a clean PR is untested.
 
+That discipline is encoded in `scripts/test_copilot_signals.py`, which pairs synthetic cases for the
+states no real PR reaches with known-answer cases against merged PRs whose state can no longer
+drift. Run it after any change to the detector:
+
+```bash
+python3 -m unittest discover -s skills/pr-review-bot-loop/scripts        # offline
+SIGNALS_LIVE=1 python3 -m unittest discover -s skills/pr-review-bot-loop/scripts
+```
+
 ---
 
 ## The loop

--- a/skills/pr-review-bot-loop/SKILL.md
+++ b/skills/pr-review-bot-loop/SKILL.md
@@ -192,9 +192,8 @@ detector drives the loop; you do not track round state separately.
 
 ### Thread hygiene
 
-Follow the global PR Review Conventions: `:zap: <commit hash>` on accepted, `:thought_balloon:
-<rationale>` on declined. Replies need the **numeric** comment id, not the GraphQL node id, which
-404s: `POST /pulls/{n}/comments/{numericId}/replies`.
+Reply in the format the global PR Review Conventions define. Replies need the **numeric** comment
+id, not the GraphQL node id, which 404s: `POST /pulls/{n}/comments/{numericId}/replies`.
 
 **Leave every bot thread open.** An open thread keeps the finding and your response visible for the
 human reviewer who comes next. This is the one action the loop must never take, and it is called out
@@ -272,6 +271,8 @@ head.
 ## Notes
 
 - Global conventions (PR Review Conventions, TDD, Definition of Done, commit and dash rules) live in
-  the global `CLAUDE.md` and `~/.claude/rules/`. This skill obeys them and does not restate them.
+  the global `CLAUDE.md` and `~/.claude/rules/`. This skill obeys them and points at them rather
+  than copying them. The one repetition it does carry is deliberate: leaving bot threads open is
+  restated here because driving toward "clean" is exactly the context that tempts you past it.
 - Related: `/pr-review` (find and format), `/pr-review-adversarial` (validate findings),
   `/pr-review-batching` (stage, never publish).

--- a/skills/pr-review-bot-loop/SKILL.md
+++ b/skills/pr-review-bot-loop/SKILL.md
@@ -28,12 +28,27 @@ surface that hides half of what it found.
 
 Run it on a PR you authored, after your own review pass, before requesting human review.
 
-Skip it when the bot has no opinion worth waiting for. On a prose-heavy diff, a clean Copilot round
-is **weak evidence**: measured across three rounds on a 280-line `SKILL.md`, Copilot produced
-exactly one finding, a grammar nit, while an adversarial pass over the same file produced two
-upgrades and a reinstated dismissal. Copilot's review is oriented at code. Run the loop anyway if
-you want the coverage, and report the result as "no automated objection" rather than as evidence of
-quality.
+**What a clean round is worth depends on the surface, and the split is sharp.** Measured across two
+PRs, the second of them five rounds over a mixed diff of roughly 450 lines of Python plus a skill
+document:
+
+| Surface | Bot loop | Adversarial pass |
+| --- | --- | --- |
+| Code | 7 | 7 |
+| Procedure (`SKILL.md`, `README`) | 1 | 6 |
+
+On code the two are comparable, and the bot is far cheaper. On the procedural half they are not
+close. So the decision rule is by surface, not by whether the diff "looks like prose":
+
+- **Mostly code:** run the loop first. It is the cheap pass and it competes on equal terms.
+- **Mostly procedure** (a skill, a rule, an agent definition, a `CLAUDE.md`): the loop is optional
+  and low-yield. Run `/pr-review-adversarial`, and treat a clean bot round as a free extra rather
+  than as the thing that clears the diff.
+
+One caveat that keeps this from overclaiming: in the measured run the adversarial reviewers were
+explicitly told to treat the skill document as procedure a later session executes literally, and the
+bot was given no such framing. Some of that 6-to-1 is prompt, not capability. Read it as "the bot
+was not asked the right question about procedure", not as "the bot cannot review procedure".
 
 **Self-review only.** Someone else's PR is out of scope in both directions: you cannot push the
 fixes, and driving a reviewer at their branch is noise they did not ask for. For a peer PR, use
@@ -254,7 +269,13 @@ When `nit_rounds` consecutive rounds produce only trivial findings, surface that
 keep going. Hitting `max_rounds` stops the loop and is a result to report, not a failure to retry.
 
 Report the outcome as a readiness statement: rounds run, findings accepted and declined per round,
-the terminating state, and what the clean pass is worth on this diff.
+and the terminating state.
+
+**Split the finding count by surface**, code against procedure, rather than asserting what the pass
+was worth. The claim "no automated objection" is not readable on its own; "7 findings on the code,
+1 on the skill document" tells a reviewer which half of the diff is still theirs to check, and it
+holds the claim in When to run it to account instead of taking it on faith. If the procedure half
+drew nothing, say so plainly rather than letting the total imply coverage it does not have.
 
 ---
 
@@ -293,8 +314,8 @@ head.
   API. It has already changed label once. When the parsed finding count disagrees with the declared
   count the script warns and you read the body directly; treat that warning as the format having
   moved.
-- **A clean pass is not evidence the diff is good**, and on prose it is barely evidence of anything.
-  It means one automated reviewer, oriented at code, raised no objection at this head.
+- **A clean pass is not evidence the diff is good.** It means one automated reviewer raised no
+  objection at this head, and what that is worth splits hard by surface: see When to run it.
 - **One adapter.** Every mechanic here is Copilot's. A repo whose automated reviewer is something
   else gets no coverage from this skill until its adapter is written.
 

--- a/skills/pr-review-bot-loop/SKILL.md
+++ b/skills/pr-review-bot-loop/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: pr-review-bot-loop
+description: >
+  Drives your own PR to a clean automated-reviewer pass before you request human review: poll for
+  the bot's verdict, triage what it posted and what it suppressed, fix, push, re-request, repeat.
+  Implements a five-signal adapter contract (re-request / pending? / landed? / clean? / suppressed?)
+  against Copilot, whose real findings hide in a collapsed block in the review body where every
+  other signal reports clean. Self-review only; it never touches someone else's PR and never merges.
+  Trigger phrases: "drive this PR to a clean bot pass", "loop until Copilot is happy", "bot review
+  loop", "did Copilot actually review the latest commit", "check for suppressed comments", "is this
+  PR ready for human review", or explicit `/pr-review-bot-loop`.
+---
+
+# PR Review Bot Loop
+
+A self-paced loop that drives **your own** PR to a state where the automated reviewer has nothing
+left to say, so a human reviewer spends their attention on design rather than on what a bot would
+have caught.
+
+It composes with its siblings rather than absorbing them. `/pr-review` finds and formats,
+`/pr-review-adversarial` decides what survives, `/pr-review-batching` stages. This skill owns the
+one thing none of them do: the round trip with a reviewer that answers on its own schedule, in a
+surface that hides half of what it found.
+
+---
+
+## When to run it
+
+Run it on a PR you authored, after your own review pass, before requesting human review.
+
+Skip it when the bot has no opinion worth waiting for. On a prose-heavy diff, a clean Copilot round
+is **weak evidence**: measured across three rounds on a 280-line `SKILL.md`, Copilot produced
+exactly one finding, a grammar nit, while an adversarial pass over the same file produced two
+upgrades and a reinstated dismissal. Copilot's review is oriented at code. Run the loop anyway if
+you want the coverage, and report the result as "no automated objection" rather than as evidence of
+quality.
+
+**Self-review only.** Someone else's PR is out of scope in both directions: you cannot push the
+fixes, and driving a reviewer at their branch is noise they did not ask for. For a peer PR, use
+`/pr-review` and stage findings through `/pr-review-batching`.
+
+---
+
+## Inputs
+
+| Input | Values | Default |
+| --- | --- | --- |
+| `pr` | PR URL or number | required |
+| `poll` | Seconds between wakeups | `90` |
+| `max_rounds` | Hard backstop on loop rounds | `5` |
+| `nit_rounds` | Consecutive trivial-only rounds before surfacing it to the user | `2` |
+
+All four are parameters. Reading them from the invocation is the point; a hardcoded poll interval
+is what makes a loop expensive on a fast bot and blind on a slow one.
+
+Confirm authorship before the first round: compare `author.login` from `gh pr view` against
+`gh api user --jq .login`. Use `dangerouslyDisableSandbox: true` for `gh` (corporate proxy TLS).
+
+---
+
+## The adapter contract
+
+Five signals. A bot adapter implements all five or it is not an adapter, because the four-signal
+version terminates early and ships defects (see The suppressed signal).
+
+| Signal | Question |
+| --- | --- |
+| `re-request` | Ask the bot to review the current head |
+| `pending?` | Is a request outstanding right now |
+| `landed?` | Does a review exist whose commit is the current head |
+| `clean?` | Did that review post actionable comments |
+| `suppressed?` | Did that review withhold findings it judged low-confidence |
+
+**Copilot is the only implemented adapter.** CodeRabbit, Codex, Sourcery, and Gemini Code Assist
+differ in every one of the five, including whether they re-review on push at all. Treat them as
+unimplemented and say so rather than assuming Copilot's mechanics generalize; the traps below were
+all measured, and guessing the equivalents for another bot reproduces none of that work.
+
+---
+
+## The Copilot adapter
+
+`landed?` and `suppressed?` ship as a script, since between them they carry every measured trap:
+
+```bash
+skills/pr-review-bot-loop/scripts/copilot-signals.py <owner> <repo> <pr-number>
+```
+
+Exit `0` clean, `1` triage-required, `2` not-applicable, `3` error. It prints the pending request,
+every Copilot review with its commit, inline count, and suppressed findings. Exit `3` is a signal
+that the query failed, so it carries **no verdict**; fix it and re-run rather than reading it as any
+of the other three.
+
+The remaining signals are single commands:
+
+| Signal | Command |
+| --- | --- |
+| `re-request` | `gh pr edit <n> --add-reviewer @copilot` |
+| `re-request` (fallback) | `gh api -X POST repos/{owner}/{repo}/pulls/{n}/requested_reviewers -f 'reviewers[]=copilot-pull-request-reviewer[bot]'` |
+| `pending?` | GraphQL `reviewRequests`, which the script already reports |
+| `clean?` corroboration | review `bodyText` contains "generated no new comments"; zero review threads created after its `submittedAt` |
+
+Four traps, each measured, each of which silently breaks a loop built without it:
+
+- **GraphQL is the only surface that shows a pending Copilot request.** Both `gh pr view --json
+  reviewRequests` and REST `/pulls/{n}/requested_reviewers` return empty while one is outstanding.
+  An adapter reading either sees a false "nothing pending", re-requests over its own live request,
+  and can loop forever.
+- **Copilot's login differs by surface**: `copilot-pull-request-reviewer` in GraphQL,
+  `copilot-pull-request-reviewer[bot]` in REST, and plain `Copilot` in the re-request response.
+  Match a substring or an explicit set of all three. Building the poll filter from the re-request
+  response's value was measured to hang a watcher straight through a landed review, a failure that
+  looks exactly like latency.
+- **The REST fallback needs the `[bot]` suffix.** Without it the call returns `422 Reviews may only
+  be requested from collaborators`, which reads as a permissions problem and is really a name format
+  problem.
+- **Reviews authored by the PR author are artifacts, not verdicts.** Every `:zap:` thread reply
+  posted over REST creates an empty-bodied `COMMENTED` review under your own login. Filter to the
+  bot before reading any verdict.
+
+Round latency was roughly 90 seconds to 2 minutes across the measured rounds, which is why `poll`
+defaults to 90 rather than the 3-to-7-minute figure in older notes.
+
+---
+
+## The suppressed signal
+
+This is the signal the skill exists for.
+
+Copilot withholds findings it judges low-confidence into a collapsed `<details>` block in the review
+**body**. They never become inline comments, so `comments.totalCount`, the "generated no new
+comments" body text, and a thread count after `submittedAt` all report clean while real defects sit
+unread. On one 5-round PR, **6 of 11 fix commits came from reviews that all three clean signals
+called clean**, including a genuine rendering bug and a regression introduced one round earlier.
+Reproduced later on a second PR, in a different area, one round after a genuinely clean round.
+
+It is three-state. Collapsing it to a boolean is a bug in opposite directions.
+
+| State | Condition | Loop action |
+| --- | --- | --- |
+| clean | review at head, nothing posted and nothing suppressed | terminate |
+| triage-required | review at head, suppressed count non-zero or unparsable | read the block, triage, fix, push, re-request |
+| not-applicable | no review at head | re-request, or wait if one is pending |
+
+- **Scope the check to the review at `headRefOid`.** A detector that scans every review on the PR
+  stays dirty forever, because an already-fixed round's suppressed block remains in the history
+  permanently. That failure presents as progress, which makes it worse than terminating early.
+- **A not-applicable result is not a clean result.** Head-scoping alone makes them the same value:
+  a PR with no review at head suppresses nothing and reads as clean. Copilot does not re-review on
+  push, so this is the silent-abandonment trap, and `suppressed?` cannot be evaluated independently
+  of `landed?`.
+- **An unparsable count is triage-required.** Silent-zero is the exact failure the signal exists to
+  prevent, so a parser that cannot read the count reports that, never zero.
+
+Two constraints hold the parser together, both live in `copilot-signals.py`, and both were measured
+by running it rather than by reading it. **Match `suppress` plus a parenthesised count**: Copilot has
+used at least two labels (`Comments suppressed due to low confidence (N)` and `Suppressed comments
+(N)`), so a detector keyed to either literal phrase under-reports on the other, and expect a third.
+**Gate on the summary text before parsing the block**: `Show a summary per file` is a benign
+`<details>` block living in the same body.
+
+**Validate a detector against a known-positive PR, and across a state transition.** Both parser
+traps and both scoping traps were found by running the thing against PRs whose answers were already
+known, never by review, and each surfaced only after the previous one was fixed. A single-round test
+cannot find them: the head-scoping trap appears only once a fix has landed. A detector validated
+only against a clean PR is untested.
+
+---
+
+## The loop
+
+Each round:
+
+1. **Read the signals.** Run `copilot-signals.py` and branch on its exit status: `0` go to
+   Termination, `1` triage, `2` re-request or wait, `3` fix the query and re-run.
+2. **Re-request only when both hold**: a new commit is at head, and nothing is pending against it.
+   A request already in flight means wait, not re-request.
+3. **Wait** with `ScheduleWakeup` at `poll`. Poll the signals again; do not conclude anything from
+   the wait itself.
+4. **Triage every finding, posted and suppressed together.** Route them through
+   `/pr-review-adversarial` Phase 2 rather than acting on them directly. Low-confidence items are
+   exactly where a refuter earns its cost: of 7 suppressed issues on the measured PR, 2 rested on
+   factually wrong premises and would have caused pointless churn.
+5. **Fix what survives**, regression test first, per the global TDD convention.
+6. **Validate, then push.** If the package manager launcher fails on an engine mismatch, run the
+   underlying tools directly (`npx tsc --build`, `npx vitest run`, `npx eslint . --max-warnings=0`);
+   a launcher that will not start is a reason to reach past it, never a reason to skip validation.
+7. **Reply to the threads** you acted on, then loop.
+
+A push moves head, which makes the next signal read `not-applicable` and sends you to step 2. The
+detector drives the loop; you do not track round state separately.
+
+### Thread hygiene
+
+Follow the global PR Review Conventions: `:zap: <commit hash>` on accepted, `:thought_balloon:
+<rationale>` on declined. Replies need the **numeric** comment id, not the GraphQL node id, which
+404s: `POST /pulls/{n}/comments/{numericId}/replies`.
+
+**Leave every bot thread open.** An open thread keeps the finding and your response visible for the
+human reviewer who comes next. This is the one action the loop must never take, and it is called out
+because the instinct while driving toward "clean" is to tidy threads shut; a session following an
+earlier version of `/pr-review` did exactly that. Resolve only threads you authored yourself.
+
+Thread replies publish the moment you post them and cannot be staged as drafts
+(`/pr-review-batching` Operation 3). Nothing in this loop is a draft.
+
+A suppressed finding has no thread at all, so there is nothing to reply to. Record its disposition in
+the commit message that fixes it, or in a PR comment when you decline it.
+
+---
+
+## Termination
+
+Terminate on **no unresolved findings you judge valid**, with `max_rounds` as a hard backstop.
+
+A genuinely empty suppressed queue is not a reachable goal. Measured across four consecutive rounds
+that every clean signal called clean, the suppressed count ran 1, 4, 2, 1: it refilled rather than
+drained, and the largest round was the third. A loop whose stopping condition is "the bot goes
+quiet" may not have a fixed point, so the judgment call is the condition and the round cap is what
+makes it terminate regardless.
+
+When `nit_rounds` consecutive rounds produce only trivial findings, surface that to the user and
+keep going. Hitting `max_rounds` stops the loop and is a result to report, not a failure to retry.
+
+Report the outcome as a readiness statement: rounds run, findings accepted and declined per round,
+the terminating state, and what the clean pass is worth on this diff.
+
+---
+
+## At scale: stacked PRs
+
+Documentation, not automation. This skill drives one PR.
+
+Give each PR in a stack its own git worktree on its own branch and run one loop per worktree. Push
+fixups only to that PR's assigned branch: a fix in a lower PR does not propagate up the stack on its
+own, so re-syncing the branches above it is a deliberate follow-up. Land the stack bottom-up.
+
+---
+
+## Out of scope
+
+**Merge.** This loop ends at a readiness report and stops. Merge gating (authorization, base-ref
+checks, closing-keyword detection, telling "no checks configured" apart from "checks pending") is
+owned by `/pr-review`'s self-review mode, which calls this loop rather than the reverse.
+
+**Finding validation.** Step 4 hands off to `/pr-review-adversarial` and consumes its verdicts.
+
+**Convergence across both passes.** This loop converges the bot. A caller that alternates bot rounds
+with adversarial rounds owns the combined stopping condition, and must consume the three-state
+result rather than a boolean: a `not-applicable` round means the bot pass did not run, which is
+neither "nothing new" nor "something new", and reading it as the former converges on an unreviewed
+head.
+
+---
+
+## Cost and known weaknesses
+
+- **Cost is wall clock, not tokens.** A round is one script run, one wakeup, and whatever the fixes
+  need. The expensive part is step 4's adversarial dispatch, at `1 + ceil(candidates / 10)`
+  subagents per round.
+- **The parser is pattern-matched against an undocumented format.** Copilot's body markup is not an
+  API. It has already changed label once. When the parsed finding count disagrees with the declared
+  count the script warns and you read the body directly; treat that warning as the format having
+  moved.
+- **A clean pass is not evidence the diff is good**, and on prose it is barely evidence of anything.
+  It means one automated reviewer, oriented at code, raised no objection at this head.
+- **One adapter.** Every mechanic here is Copilot's. A repo whose automated reviewer is something
+  else gets no coverage from this skill until its adapter is written.
+
+---
+
+## Notes
+
+- Global conventions (PR Review Conventions, TDD, Definition of Done, commit and dash rules) live in
+  the global `CLAUDE.md` and `~/.claude/rules/`. This skill obeys them and does not restate them.
+- Related: `/pr-review` (find and format), `/pr-review-adversarial` (validate findings),
+  `/pr-review-batching` (stage, never publish).

--- a/skills/pr-review-bot-loop/scripts/copilot-signals.py
+++ b/skills/pr-review-bot-loop/scripts/copilot-signals.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Report Copilot's loop-terminating signals for one PR.
+
+Usage: copilot-signals.py <owner> <repo> <pr-number>
+
+Answers the two signals that decide whether the bot loop terminates, and prints
+the corroborating detail for the rest.
+
+Exit status is the three-state `landed? + suppressed?` result:
+
+    0  clean            review at head, no inline comments, nothing suppressed
+    1  triage-required  review at head withheld or posted findings
+    2  not-applicable   no review at head; re-request, or wait if one is pending
+    3  error            the query or the arguments failed; no verdict
+
+`landed?` and `suppressed?` cannot be answered independently: with no review at
+head there is nothing to suppress, so a head-scoped suppressed check reports the
+same zero for "clean" and for "never reviewed". Exit 2 keeps them distinct.
+
+Inline comments fold into exit 1 alongside suppressed ones so that exit 0 is safe
+to read as "terminate". Both need the same loop action; the printout separates
+them.
+"""
+import json
+import re
+import subprocess
+import sys
+
+CLEAN, TRIAGE_REQUIRED, NOT_APPLICABLE, ERROR = 0, 1, 2, 3
+
+QUERY = """
+query($owner:String!, $repo:String!, $number:Int!) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$number) {
+      headRefOid
+      reviewRequests(first:20) {
+        nodes { requestedReviewer { __typename ... on Bot { login } ... on User { login } } }
+      }
+      reviews(last:50) {
+        nodes {
+          author { login }
+          submittedAt
+          commit { oid }
+          comments { totalCount }
+          body
+        }
+      }
+    }
+  }
+}
+"""
+
+# Copilot's login differs by surface: `copilot-pull-request-reviewer` in GraphQL,
+# `copilot-pull-request-reviewer[bot]` in REST, and plain `Copilot` in the
+# re-request response. A filter built by equality against any one of them
+# silently never matches, which presents as a review that never lands.
+COPILOT = re.compile(r"copilot", re.IGNORECASE)
+# The count lives in the <summary>. Copilot has used at least two labels:
+# "Comments suppressed due to low confidence (N)" and "Suppressed comments (N)".
+# Match the word "suppress" plus a parenthesised count rather than either fixed
+# phrase, or a label change reports zero and the loop terminates on findings it
+# never read. Expect a third label.
+SUPPRESSED_SUMMARY = re.compile(r"suppress\w*", re.IGNORECASE)
+COUNT_IN_SUMMARY = re.compile(r"\((\d+)\)")
+# Gate on the summary text: "Show a summary per file" is a benign <details> block
+# that coexists with the suppressed block in the same body.
+DETAILS_BLOCK = re.compile(
+    r"<details>\s*<summary>(?P<summary>.*?)</summary>(?P<inner>.*?)</details>",
+    re.DOTALL,
+)
+# Inside the block each finding is "**path/to/file.ext**" followed by prose.
+FINDING = re.compile(r"\*\*(?P<file>[^*\n]+?)\*\*\s*(?P<text>.*?)(?=\n\s*\*\*|\Z)", re.DOTALL)
+
+
+def parse_suppressed(body):
+    """Return (declared_count, [(file, text), ...], [summary_labels]).
+
+    declared_count is None when a suppressed block exists but declares no
+    parsable count. Callers treat that as triage-required, never as zero;
+    silent-zero is the failure this whole signal exists to prevent.
+    """
+    count = None
+    findings = []
+    labels = []
+    for block in DETAILS_BLOCK.finditer(body):
+        summary = block.group("summary")
+        if not SUPPRESSED_SUMMARY.search(summary):
+            continue
+        labels.append(" ".join(summary.split()))
+        match = COUNT_IN_SUMMARY.search(summary)
+        if match:
+            count = (count or 0) + int(match.group(1))
+        for finding in FINDING.finditer(block.group("inner")):
+            text = " ".join(finding.group("text").split())
+            if text:
+                findings.append((finding.group("file").strip(), text))
+    return count, findings, labels
+
+
+def fetch(owner, repo, number):
+    result = subprocess.run(
+        ["gh", "api", "graphql", "-f", f"query={QUERY}",
+         "-f", f"owner={owner}", "-f", f"repo={repo}", "-F", f"number={number}"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "gh api graphql failed")
+    payload = json.loads(result.stdout)
+    if payload.get("errors"):
+        raise RuntimeError(json.dumps(payload["errors"]))
+    return payload["data"]["repository"]["pullRequest"]
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(__doc__.strip(), file=sys.stderr)
+        return ERROR
+    try:
+        pr = fetch(sys.argv[1], sys.argv[2], sys.argv[3])
+    except Exception as error:  # noqa: BLE001 - any failure means "no verdict"
+        print(f"ERROR: {error}", file=sys.stderr)
+        return ERROR
+
+    head = pr["headRefOid"]
+    print(f"head {head}")
+
+    # GraphQL is the only surface that shows a pending Copilot request. Both
+    # `gh pr view --json reviewRequests` and REST /requested_reviewers return
+    # empty while one is outstanding, so an adapter reading either double-requests.
+    pending = [
+        (node["requestedReviewer"] or {}).get("login", "?")
+        for node in pr["reviewRequests"]["nodes"]
+        if COPILOT.search((node["requestedReviewer"] or {}).get("login", ""))
+    ]
+    print(f"pending {pending if pending else 'none'}")
+
+    at_head = None
+    for review in pr["reviews"]["nodes"]:
+        # Our own `:zap:` thread replies create author-authored COMMENTED review
+        # artifacts with empty bodies. Only Copilot's reviews are verdicts.
+        if not COPILOT.search(review["author"]["login"] if review["author"] else ""):
+            continue
+        oid = (review["commit"] or {}).get("oid")
+        count, findings, labels = parse_suppressed(review["body"] or "")
+        inline = review["comments"]["totalCount"]
+        where = "AT HEAD" if oid == head else f"at {oid[:7] if oid else 'unknown'}"
+        if not labels:
+            shown = "none"
+        else:
+            shown = f"{count if count is not None else 'UNDECLARED'} via {labels}"
+        print(f"\n=== review {review['submittedAt']} {where} "
+              f"inline={inline} suppressed={shown}")
+        for path, text in findings:
+            print(f"  - {path}: {text[:300]}")
+        if count is not None and len(findings) != count:
+            print(f"  WARNING: declared {count}, parsed {len(findings)}; "
+                  f"read the review body directly")
+        if oid == head:
+            at_head = (inline, count, labels)
+
+    # Only the review at head decides the loop. A historical review's suppressed
+    # block was already triaged and fixed, but it stays in the PR forever, so a
+    # detector scanning every review never reaches clean. That failure presents
+    # as progress, which makes it worse than terminating early.
+    if at_head is None:
+        print("\nNOT APPLICABLE: no Copilot review at head. Copilot does not "
+              "re-review on push, so this is silent abandonment, not clean. "
+              "Re-request, or wait if one is already pending.")
+        return NOT_APPLICABLE
+    inline, count, labels = at_head
+    if inline or (labels and (count is None or count > 0)):
+        print(f"\nTRIAGE REQUIRED: {inline} inline, "
+              f"{count if count is not None else 'an undeclared number of'} suppressed.")
+        return TRIAGE_REQUIRED
+    print("\nCLEAN: a review at head posted nothing and withheld nothing.")
+    return CLEAN
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/pr-review-bot-loop/scripts/copilot-signals.py
+++ b/skills/pr-review-bot-loop/scripts/copilot-signals.py
@@ -122,11 +122,9 @@ def main():
     except ValueError:
         print(f"ERROR: pr-number must be an integer, got {sys.argv[3]!r}", file=sys.stderr)
         return ERROR
-    try:
-        pr = fetch(sys.argv[1], sys.argv[2], number)
-    except Exception as error:  # noqa: BLE001 - any failure means "no verdict"
-        print(f"ERROR: {error}", file=sys.stderr)
-        return ERROR
+    pr = fetch(sys.argv[1], sys.argv[2], number)
+    if pr is None:
+        raise RuntimeError(f"no pull request {number} in {sys.argv[1]}/{sys.argv[2]}")
 
     head = pr["headRefOid"]
     print(f"head {head}")
@@ -195,4 +193,11 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    # Every unexpected failure has to land on ERROR. An uncaught exception would
+    # exit 1, which is TRIAGE_REQUIRED, so a crash would read to the loop as a
+    # verdict. Reporting no verdict is the one thing this script must get right.
+    try:
+        sys.exit(main())
+    except Exception as error:  # noqa: BLE001
+        print(f"ERROR: {error}", file=sys.stderr)
+        sys.exit(ERROR)

--- a/skills/pr-review-bot-loop/scripts/copilot-signals.py
+++ b/skills/pr-review-bot-loop/scripts/copilot-signals.py
@@ -158,10 +158,13 @@ def main():
     # GraphQL is the only surface that shows a pending Copilot request. Both
     # `gh pr view --json reviewRequests` and REST /requested_reviewers return
     # empty while one is outstanding, so an adapter reading either double-requests.
+    # Same two conditions as the review filter below. A human collaborator whose
+    # login contains "copilot" would otherwise read as a pending bot request,
+    # which parks the loop in wait instead of re-requesting.
     pending = [
-        (node["requestedReviewer"] or {}).get("login", "?")
-        for node in pr["reviewRequests"]["nodes"]
-        if COPILOT.search((node["requestedReviewer"] or {}).get("login", ""))
+        reviewer["login"]
+        for reviewer in (node["requestedReviewer"] or {} for node in pr["reviewRequests"]["nodes"])
+        if reviewer.get("__typename") == "Bot" and COPILOT.search(reviewer.get("login") or "")
     ]
     print(f"pending {pending if pending else 'none'}")
 

--- a/skills/pr-review-bot-loop/scripts/copilot-signals.py
+++ b/skills/pr-review-bot-loop/scripts/copilot-signals.py
@@ -134,7 +134,14 @@ def fetch(owner, repo, number):
     payload = json.loads(result.stdout)
     if payload.get("errors"):
         raise RuntimeError(json.dumps(payload["errors"]))
-    return payload["data"]["repository"]["pullRequest"]
+    repository = (payload.get("data") or {}).get("repository")
+    if repository is None:
+        # GitHub returns NOT_FOUND in `errors` for a missing or unreadable repo,
+        # so this is caught above in practice. The guard exists because the exit
+        # status is the interface: without it the message is a bare "'NoneType'
+        # object is not subscriptable", which says nothing about what to fix.
+        raise RuntimeError(f"cannot read {owner}/{repo}: no such repository, or no access")
+    return repository["pullRequest"]
 
 
 def main():

--- a/skills/pr-review-bot-loop/scripts/copilot-signals.py
+++ b/skills/pr-review-bot-loop/scripts/copilot-signals.py
@@ -20,6 +20,13 @@ same zero for "clean" and for "never reviewed". Exit 2 keeps them distinct.
 Inline comments fold into exit 1 alongside suppressed ones so that exit 0 is safe
 to read as "terminate". Both need the same loop action; the printout separates
 them.
+
+Known bound: the query reads the newest 50 reviews. Each thread reply posted over
+REST adds an author-authored review artifact, so a PR that accumulated more than
+50 of them after its head review would push that review out of the window and
+report not-applicable. Reaching it takes 50-plus replies with no push in between,
+roughly ten times anything measured, and the loop's round cap bounds the outcome
+to a wrong report rather than a hang.
 """
 import json
 import re
@@ -38,7 +45,7 @@ query($owner:String!, $repo:String!, $number:Int!) {
       }
       reviews(last:50) {
         nodes {
-          author { login }
+          author { __typename login }
           submittedAt
           commit { oid }
           comments { totalCount }
@@ -64,24 +71,41 @@ SUPPRESSED_SUMMARY = re.compile(r"suppress\w*", re.IGNORECASE)
 COUNT_IN_SUMMARY = re.compile(r"\((\d+)\)")
 # Gate on the summary text: "Show a summary per file" is a benign <details> block
 # that coexists with the suppressed block in the same body.
+#
+# The container is drift-hardened for the same reason the label is. Attributes
+# (<details open>) or different casing would otherwise parse as "no suppressed
+# block", which returns CLEAN and terminates the loop on withheld findings. The
+# floor of matching HTML with a regex is a quoted attribute containing ">"; that
+# is not worth chasing, and it fails toward CLEAN, so the count mismatch below is
+# what catches it.
+#
+# Deliberately NOT here: a body-level backstop treating /suppress/i anywhere in
+# the body as triage. Copilot's overview table restates each changed file's
+# description, so on a PR that mentions suppression the phrase appears in a
+# genuinely clean review body. That backstop was measured firing on this repo's
+# own clean rounds, which is a loop with no fixed point: worse than the early
+# termination it would be trying to prevent.
 DETAILS_BLOCK = re.compile(
-    r"<details>\s*<summary>(?P<summary>.*?)</summary>(?P<inner>.*?)</details>",
-    re.DOTALL,
+    r"<details[^>]*>\s*<summary[^>]*>(?P<summary>.*?)</summary>(?P<inner>.*?)</details>",
+    re.DOTALL | re.IGNORECASE,
 )
 # Inside the block each finding is "**path/to/file.ext**" followed by prose.
 FINDING = re.compile(r"\*\*(?P<file>[^*\n]+?)\*\*\s*(?P<text>.*?)(?=\n\s*\*\*|\Z)", re.DOTALL)
 
 
 def parse_suppressed(body):
-    """Return (declared_count, [(file, text), ...], [summary_labels]).
+    """Return (declared_count, [(file, text), ...], [summary_labels], undeclared).
 
-    declared_count is None when a suppressed block exists but declares no
-    parsable count. Callers treat that as triage-required, never as zero;
-    silent-zero is the failure this whole signal exists to prevent.
+    `undeclared` is True when any suppressed block declared no parsable count.
+    It is tracked separately from the running total because summing across
+    blocks would otherwise erase it: an undeclared block followed by one
+    declaring (0) collapses to a count of 0, and silent-zero is the failure this
+    whole signal exists to prevent.
     """
     count = None
     findings = []
     labels = []
+    undeclared = False
     for block in DETAILS_BLOCK.finditer(body):
         summary = block.group("summary")
         if not SUPPRESSED_SUMMARY.search(summary):
@@ -90,11 +114,13 @@ def parse_suppressed(body):
         match = COUNT_IN_SUMMARY.search(summary)
         if match:
             count = (count or 0) + int(match.group(1))
+        else:
+            undeclared = True
         for finding in FINDING.finditer(block.group("inner")):
             text = " ".join(finding.group("text").split())
             if text:
                 findings.append((finding.group("file").strip(), text))
-    return count, findings, labels
+    return count, findings, labels, undeclared
 
 
 def fetch(owner, repo, number):
@@ -144,21 +170,38 @@ def main():
     for review in pr["reviews"]["nodes"]:
         # Our own `:zap:` thread replies create author-authored COMMENTED review
         # artifacts with empty bodies. Only Copilot's reviews are verdicts.
-        if not COPILOT.search(review["author"]["login"] if review["author"] else ""):
+        #
+        # Two independent conditions. Requiring __typename Bot excludes a human
+        # collaborator whose login happens to contain "copilot", and the login
+        # match stays a loose substring on purpose: the bot's login differs
+        # across API surfaces, and anchoring it would trade a false positive
+        # that needs a hostile-named collaborator for a false negative on any
+        # future surface, which presents as a review that never lands.
+        author = review["author"] or {}
+        if author.get("__typename") != "Bot":
+            continue
+        if not COPILOT.search(author.get("login") or ""):
             continue
         oid = (review["commit"] or {}).get("oid")
-        count, findings, labels = parse_suppressed(review["body"] or "")
+        count, findings, labels, undeclared = parse_suppressed(review["body"] or "")
         inline = review["comments"]["totalCount"]
         where = "AT HEAD" if oid == head else f"at {oid[:7] if oid else 'unknown'}"
         if not labels:
             shown = "none"
+        elif undeclared and count is None:
+            shown = f"UNDECLARED via {labels}"
+        elif undeclared:
+            shown = f"{count} declared plus an undeclared block via {labels}"
         else:
-            shown = f"{count if count is not None else 'UNDECLARED'} via {labels}"
+            shown = f"{count} via {labels}"
         print(f"\n=== review {review['submittedAt']} {where} "
               f"inline={inline} suppressed={shown}")
         for path, text in findings:
             print(f"  - {path}: {text[:300]}")
-        if count is not None and len(findings) != count:
+        # Only meaningful when every block declared a count; with a mixed body
+        # `count` sums the declared blocks while `findings` spans all of them,
+        # so the comparison would warn spuriously.
+        if not undeclared and count is not None and len(findings) != count:
             print(f"  WARNING: declared {count}, parsed {len(findings)}; "
                   f"read the review body directly")
         # A head can carry more than one review (re-requested without pushing), and
@@ -166,7 +209,7 @@ def main():
         # not a contract. Decide on the most recently submitted one explicitly.
         submitted = review["submittedAt"] or ""
         if oid == head and submitted >= at_head_submitted:
-            at_head = (inline, count, labels, len(findings))
+            at_head = (inline, count, labels, len(findings), undeclared)
             at_head_submitted = submitted
 
     # Only the review at head decides the loop. A historical review's suppressed
@@ -178,21 +221,21 @@ def main():
               "re-review on push, so this is silent abandonment, not clean. "
               "Re-request, or wait if one is already pending.")
         return NOT_APPLICABLE
-    inline, count, labels, parsed = at_head
+    inline, count, labels, parsed, undeclared = at_head
     if not labels:
         withheld = "no suppressed block"
-    elif count is None:
+    elif undeclared:
         withheld = "a suppressed block declaring no parsable count"
     elif parsed != count:
         withheld = f"a suppressed block declaring {count} but carrying {parsed}"
     else:
         withheld = f"{count} suppressed"
-    # Parsed findings decide alongside the declared count, never under it. A block
-    # that declares (0) while carrying findings is a silent zero, which is the
-    # failure this signal exists to prevent, and it is the assertive kind: the
-    # count mismatch means the body format moved and the parse is no longer
-    # trustworthy in either direction.
-    if inline or parsed or (labels and (count is None or count > 0)):
+    # Parsed findings and an undeclared count each decide alongside the declared
+    # total, never under it. A block that declares (0) while carrying findings is
+    # a silent zero, which is the failure this signal exists to prevent, and it is
+    # the assertive kind: the mismatch means the body format moved and the parse
+    # is no longer trustworthy in either direction.
+    if inline or parsed or undeclared or (labels and (count is None or count > 0)):
         print(f"\nTRIAGE REQUIRED: {inline} inline, {withheld}.")
         return TRIAGE_REQUIRED
     print("\nCLEAN: a review at head posted nothing and withheld nothing.")

--- a/skills/pr-review-bot-loop/scripts/copilot-signals.py
+++ b/skills/pr-review-bot-loop/scripts/copilot-signals.py
@@ -166,7 +166,7 @@ def main():
         # not a contract. Decide on the most recently submitted one explicitly.
         submitted = review["submittedAt"] or ""
         if oid == head and submitted >= at_head_submitted:
-            at_head = (inline, count, labels)
+            at_head = (inline, count, labels, len(findings))
             at_head_submitted = submitted
 
     # Only the review at head decides the loop. A historical review's suppressed
@@ -178,14 +178,21 @@ def main():
               "re-review on push, so this is silent abandonment, not clean. "
               "Re-request, or wait if one is already pending.")
         return NOT_APPLICABLE
-    inline, count, labels = at_head
+    inline, count, labels, parsed = at_head
     if not labels:
         withheld = "no suppressed block"
     elif count is None:
         withheld = "a suppressed block declaring no parsable count"
+    elif parsed != count:
+        withheld = f"a suppressed block declaring {count} but carrying {parsed}"
     else:
         withheld = f"{count} suppressed"
-    if inline or (labels and (count is None or count > 0)):
+    # Parsed findings decide alongside the declared count, never under it. A block
+    # that declares (0) while carrying findings is a silent zero, which is the
+    # failure this signal exists to prevent, and it is the assertive kind: the
+    # count mismatch means the body format moved and the parse is no longer
+    # trustworthy in either direction.
+    if inline or parsed or (labels and (count is None or count > 0)):
         print(f"\nTRIAGE REQUIRED: {inline} inline, {withheld}.")
         return TRIAGE_REQUIRED
     print("\nCLEAN: a review at head posted nothing and withheld nothing.")

--- a/skills/pr-review-bot-loop/scripts/copilot-signals.py
+++ b/skills/pr-review-bot-loop/scripts/copilot-signals.py
@@ -116,7 +116,14 @@ def main():
         print(__doc__.strip(), file=sys.stderr)
         return ERROR
     try:
-        pr = fetch(sys.argv[1], sys.argv[2], sys.argv[3])
+        # The query declares number as Int!, so coerce here rather than letting a
+        # bad argument surface as a GraphQL type error from two layers down.
+        number = int(sys.argv[3])
+    except ValueError:
+        print(f"ERROR: pr-number must be an integer, got {sys.argv[3]!r}", file=sys.stderr)
+        return ERROR
+    try:
+        pr = fetch(sys.argv[1], sys.argv[2], number)
     except Exception as error:  # noqa: BLE001 - any failure means "no verdict"
         print(f"ERROR: {error}", file=sys.stderr)
         return ERROR
@@ -135,6 +142,7 @@ def main():
     print(f"pending {pending if pending else 'none'}")
 
     at_head = None
+    at_head_submitted = ""
     for review in pr["reviews"]["nodes"]:
         # Our own `:zap:` thread replies create author-authored COMMENTED review
         # artifacts with empty bodies. Only Copilot's reviews are verdicts.
@@ -155,8 +163,13 @@ def main():
         if count is not None and len(findings) != count:
             print(f"  WARNING: declared {count}, parsed {len(findings)}; "
                   f"read the review body directly")
-        if oid == head:
+        # A head can carry more than one review (re-requested without pushing), and
+        # PullRequest.reviews takes no orderBy argument, so the connection's order is
+        # not a contract. Decide on the most recently submitted one explicitly.
+        submitted = review["submittedAt"] or ""
+        if oid == head and submitted >= at_head_submitted:
             at_head = (inline, count, labels)
+            at_head_submitted = submitted
 
     # Only the review at head decides the loop. A historical review's suppressed
     # block was already triaged and fixed, but it stays in the PR forever, so a
@@ -168,9 +181,14 @@ def main():
               "Re-request, or wait if one is already pending.")
         return NOT_APPLICABLE
     inline, count, labels = at_head
+    if not labels:
+        withheld = "no suppressed block"
+    elif count is None:
+        withheld = "a suppressed block declaring no parsable count"
+    else:
+        withheld = f"{count} suppressed"
     if inline or (labels and (count is None or count > 0)):
-        print(f"\nTRIAGE REQUIRED: {inline} inline, "
-              f"{count if count is not None else 'an undeclared number of'} suppressed.")
+        print(f"\nTRIAGE REQUIRED: {inline} inline, {withheld}.")
         return TRIAGE_REQUIRED
     print("\nCLEAN: a review at head posted nothing and withheld nothing.")
     return CLEAN

--- a/skills/pr-review-bot-loop/scripts/test_copilot_signals.py
+++ b/skills/pr-review-bot-loop/scripts/test_copilot_signals.py
@@ -16,11 +16,15 @@ transition rather than at a single point.
 import contextlib
 import importlib.util
 import io
+import json
 import os
 import subprocess
 import sys
+import tempfile
+import textwrap
 import unittest
 from pathlib import Path
+from unittest import mock
 
 SCRIPT = Path(__file__).with_name("copilot-signals.py")
 
@@ -57,10 +61,21 @@ BENIGN = "<details><summary>Show a summary per file</summary>\n**src/a.py** fine
 
 
 def review(oid, inline=0, body="", when="2026-01-01T00:00:00Z",
-           login="copilot-pull-request-reviewer"):
-    return {"author": {"login": login}, "submittedAt": when,
-            "commit": {"oid": oid}, "comments": {"totalCount": inline},
-            "body": body}
+           login="copilot-pull-request-reviewer", typename="Bot"):
+    return {"author": {"__typename": typename, "login": login},
+            "submittedAt": when, "commit": {"oid": oid},
+            "comments": {"totalCount": inline}, "body": body}
+
+
+def payload(reviews, head=HEAD, pending=()):
+    return {
+        "headRefOid": head,
+        "reviewRequests": {"nodes": [
+            {"requestedReviewer": {"__typename": "Bot", "login": login}}
+            for login in pending
+        ]},
+        "reviews": {"nodes": reviews},
+    }
 
 
 class ClassificationTests(unittest.TestCase):
@@ -74,14 +89,18 @@ class ClassificationTests(unittest.TestCase):
         finally:
             sys.argv = argv
 
-    def assertVerdict(self, reviews, expected, head=HEAD):
-        signals.fetch = lambda owner, repo, number: {
-            "headRefOid": head,
-            "reviewRequests": {"nodes": []},
-            "reviews": {"nodes": reviews},
-        }
-        with contextlib.redirect_stdout(io.StringIO()):
-            self.assertEqual(self._run(), expected)
+    def verdict(self, reviews, head=HEAD, pending=()):
+        """Return (exit status, stdout). Patch is scoped, never left behind."""
+        out = io.StringIO()
+        with mock.patch.object(signals, "fetch",
+                               lambda owner, repo, number: payload(reviews, head, pending)):
+            with contextlib.redirect_stdout(out):
+                code = self._run()
+        return code, out.getvalue()
+
+    def assertVerdict(self, reviews, expected, head=HEAD, pending=()):
+        code, _ = self.verdict(reviews, head, pending)
+        self.assertEqual(code, expected)
 
     def test_no_review_at_head_is_not_applicable(self):
         """The silent-abandonment trap. Never read this as clean."""
@@ -142,38 +161,172 @@ class ClassificationTests(unittest.TestCase):
              review(HEAD, body=SUPPRESSED_TWO, when="2026-01-02T00:00:00Z")],
             signals.TRIAGE_REQUIRED)
 
+    def test_container_attributes_do_not_hide_a_suppressed_block(self):
+        """<details open> parsed as no block, which returned CLEAN on findings."""
+        for markup in (
+            '<details open><summary>Suppressed comments (1)</summary>\n'
+            '**src/a.py** x\n</details>',
+            '<details><summary class="y">Suppressed comments (1)</summary>\n'
+            '**src/a.py** x\n</details>',
+            '<DETAILS><SUMMARY>Suppressed comments (1)</SUMMARY>\n'
+            '**src/a.py** x\n</DETAILS>',
+        ):
+            with self.subTest(markup=markup[:32]):
+                self.assertVerdict([review(HEAD, body=markup)],
+                                   signals.TRIAGE_REQUIRED)
+
+    def test_clean_body_mentioning_suppression_stays_clean(self):
+        """Copilot's overview table restates file descriptions.
+
+        A body-level /suppress/ backstop was measured firing on this repo's own
+        clean rounds, which is a loop with no fixed point.
+        """
+        body = ("## Pull request overview\n\n| File | Description |\n"
+                "| --- | --- |\n| signals.py | detects suppressed findings |\n")
+        self.assertVerdict([review(HEAD, body=body)], signals.CLEAN)
+
+    def test_undeclared_block_survives_a_later_declared_zero(self):
+        self.assertVerdict(
+            [review(HEAD, body=SUPPRESSED_UNDECLARED + "\n" + SUPPRESSED_EMPTY)],
+            signals.TRIAGE_REQUIRED)
+
+    def test_human_login_containing_copilot_is_not_a_verdict(self):
+        """__typename excludes the human; the login match stays deliberately loose."""
+        self.assertVerdict(
+            [review(HEAD, login="copilotfan", typename="User")],
+            signals.NOT_APPLICABLE)
+
     def test_historical_suppressed_block_does_not_keep_the_loop_dirty(self):
         """Head-scoping. Without it an already-fixed round never reaches clean."""
         self.assertVerdict(
             [review(OLD, body=SUPPRESSED_TWO), review(HEAD)], signals.CLEAN)
 
 
+class ReportTests(unittest.TestCase):
+    """The printed report is the other half of the interface.
+
+    The exit status cannot express `pending`, and the loop's re-request gate
+    reads it, so both branches need cover. Left untested it is the signal whose
+    failure mode is a watcher that waits through a landed review.
+    """
+
+    def report(self, reviews, head=HEAD, pending=()):
+        return ClassificationTests.verdict(self, reviews, head, pending)[1]
+
+    _run = ClassificationTests._run
+
+    def test_reports_no_pending_request(self):
+        self.assertIn("pending none", self.report([review(HEAD)]))
+
+    def test_reports_a_pending_request(self):
+        out = self.report([review(HEAD)], pending=["copilot-pull-request-reviewer"])
+        self.assertIn("copilot-pull-request-reviewer", out.splitlines()[1])
+
+    def test_non_copilot_requested_reviewer_is_not_reported_as_pending(self):
+        self.assertIn("pending none",
+                      self.report([review(HEAD)], pending=["some-human"]))
+
+    def test_reports_head_and_each_review(self):
+        out = self.report([review(OLD), review(HEAD, inline=2)])
+        self.assertIn(f"head {HEAD}", out)
+        self.assertIn("AT HEAD", out)
+        self.assertEqual(out.count("=== review"), 2)
+
+    def test_warns_when_declared_and_parsed_counts_disagree(self):
+        self.assertIn("WARNING", self.report(
+            [review(HEAD, body=SUPPRESSED_ZERO_WITH_FINDINGS)]))
+
+    def test_no_spurious_warning_when_a_block_is_undeclared(self):
+        """count sums declared blocks while findings span all of them."""
+        self.assertNotIn("WARNING", self.report(
+            [review(HEAD, body=SUPPRESSED_UNDECLARED + "\n" + SUPPRESSED_EMPTY)]))
+
+
+class ErrorPathTests(unittest.TestCase):
+    """Every failure must land on ERROR rather than on a verdict.
+
+    These run the script as a subprocess with a stubbed `gh` so they stay
+    offline, which is what lets CI cover the top-level handler.
+    """
+
+    def run_with_gh(self, stdout="", returncode=0, stderr=""):
+        with tempfile.TemporaryDirectory() as tmp:
+            stub = Path(tmp) / "gh"
+            stub.write_text(textwrap.dedent(f"""\
+                #!/bin/sh
+                cat <<'STUB_EOF'
+                {stdout}
+                STUB_EOF
+                printf '%s' {json.dumps(stderr)} >&2
+                exit {returncode}
+                """))
+            stub.chmod(0o755)
+            env = dict(os.environ)
+            # Prepend. Replacing PATH would break the stub's own `cat`, and every
+            # case would still exit 3 while asserting nothing.
+            env["PATH"] = tmp + os.pathsep + env["PATH"]
+            return subprocess.run(
+                [sys.executable, str(SCRIPT), "owner", "repo", "1"],
+                capture_output=True, text=True, env=env)
+
+    def assertNoVerdict(self, result):
+        self.assertEqual(result.returncode, signals.ERROR)
+        self.assertIn("ERROR", result.stderr)
+
+    def test_gh_failure_is_error(self):
+        self.assertNoVerdict(self.run_with_gh(returncode=1, stderr="gh: auth required"))
+
+    def test_graphql_errors_payload_is_error(self):
+        self.assertNoVerdict(self.run_with_gh(stdout=json.dumps(
+            {"data": None, "errors": [{"message": "Could not resolve to a Repository"}]})))
+
+    def test_malformed_json_is_error(self):
+        self.assertNoVerdict(self.run_with_gh(stdout="not json at all"))
+
+    def test_null_repository_is_error(self):
+        self.assertNoVerdict(self.run_with_gh(stdout=json.dumps(
+            {"data": {"repository": None}})))
+
+    def test_null_pull_request_is_error(self):
+        result = self.run_with_gh(stdout=json.dumps(
+            {"data": {"repository": {"pullRequest": None}}}))
+        self.assertNoVerdict(result)
+        self.assertIn("no pull request 1", result.stderr)
+
+    def test_stub_reaches_a_real_verdict_on_a_well_formed_payload(self):
+        """Guards the stub itself: without this the cases above could pass vacuously."""
+        result = self.run_with_gh(stdout=json.dumps(
+            {"data": {"repository": {"pullRequest": payload([review(HEAD)])}}}))
+        self.assertEqual(result.returncode, signals.CLEAN)
+        self.assertIn("CLEAN", result.stdout)
+
+
 class ParserTests(unittest.TestCase):
     def test_matches_both_observed_labels(self):
         for body, expected in ((SUPPRESSED_TWO, 2), (OLD_LABEL, 3)):
             with self.subTest(body=body[:40]):
-                count, _, labels = signals.parse_suppressed(body)
+                count, _, labels, _ = signals.parse_suppressed(body)
                 self.assertEqual(count, expected)
                 self.assertTrue(labels)
 
     def test_ignores_benign_details_block(self):
-        count, findings, labels = signals.parse_suppressed(BENIGN)
+        count, findings, labels, _ = signals.parse_suppressed(BENIGN)
         self.assertIsNone(count)
         self.assertEqual(findings, [])
         self.assertEqual(labels, [])
 
     def test_unparsable_count_is_none_not_zero(self):
-        count, findings, labels = signals.parse_suppressed(SUPPRESSED_UNDECLARED)
+        count, findings, labels, _ = signals.parse_suppressed(SUPPRESSED_UNDECLARED)
         self.assertIsNone(count)
         self.assertTrue(labels)
         self.assertEqual(len(findings), 1)
 
     def test_extracts_file_and_text_per_finding(self):
-        _, findings, _ = signals.parse_suppressed(SUPPRESSED_TWO)
+        _, findings, _, _ = signals.parse_suppressed(SUPPRESSED_TWO)
         self.assertEqual([path for path, _ in findings], ["src/a.py", "src/b.py"])
 
     def test_suppressed_and_benign_blocks_coexist(self):
-        count, findings, _ = signals.parse_suppressed(BENIGN + "\n" + SUPPRESSED_TWO)
+        count, findings, _, _ = signals.parse_suppressed(BENIGN + "\n" + SUPPRESSED_TWO)
         self.assertEqual(count, 2)
         self.assertEqual(len(findings), 2)
 

--- a/skills/pr-review-bot-loop/scripts/test_copilot_signals.py
+++ b/skills/pr-review-bot-loop/scripts/test_copilot_signals.py
@@ -301,8 +301,11 @@ class ErrorPathTests(unittest.TestCase):
         self.assertNoVerdict(self.run_with_gh(stdout="not json at all"))
 
     def test_null_repository_is_error(self):
-        self.assertNoVerdict(self.run_with_gh(stdout=json.dumps(
-            {"data": {"repository": None}})))
+        result = self.run_with_gh(stdout=json.dumps({"data": {"repository": None}}))
+        self.assertNoVerdict(result)
+        # The exit status was always right; the message was "'NoneType' object is
+        # not subscriptable", which tells the reader nothing about what to fix.
+        self.assertIn("no such repository, or no access", result.stderr)
 
     def test_null_pull_request_is_error(self):
         result = self.run_with_gh(stdout=json.dumps(

--- a/skills/pr-review-bot-loop/scripts/test_copilot_signals.py
+++ b/skills/pr-review-bot-loop/scripts/test_copilot_signals.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Tests for copilot-signals.py.
+
+    python3 -m unittest discover -s skills/pr-review-bot-loop/scripts -v
+
+Offline by default. The live cases need network and an authenticated `gh`, so
+they are opt-in:
+
+    SIGNALS_LIVE=1 python3 -m unittest discover -s skills/pr-review-bot-loop/scripts
+
+Both halves matter. The synthetic cases cover states no PR in this repo can
+reach, and the live cases are the discipline the skill itself prescribes:
+validate the detector against a PR whose answer is already known, across a state
+transition rather than at a single point.
+"""
+import contextlib
+import importlib.util
+import io
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("copilot-signals.py")
+
+
+def load():
+    spec = importlib.util.spec_from_file_location("copilot_signals", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+signals = load()
+
+HEAD = "a" * 40
+OLD = "b" * 40
+
+SUPPRESSED_TWO = (
+    "<details><summary>Suppressed comments (2)</summary>\n"
+    "**src/a.py** one\n**src/b.py** two\n</details>"
+)
+SUPPRESSED_ZERO_WITH_FINDINGS = (
+    "<details><summary>Suppressed comments (0)</summary>\n"
+    "**src/a.py** something real was withheld here\n</details>"
+)
+SUPPRESSED_EMPTY = "<details><summary>Suppressed comments (0)</summary>\n</details>"
+SUPPRESSED_UNDECLARED = (
+    "<details><summary>Suppressed comments</summary>\n**src/a.py** x\n</details>"
+)
+OLD_LABEL = (
+    "<details><summary>Comments suppressed due to low confidence (3)</summary>\n"
+    "**src/a.py** one\n**src/b.py** two\n**src/c.py** three\n</details>"
+)
+BENIGN = "<details><summary>Show a summary per file</summary>\n**src/a.py** fine\n</details>"
+
+
+def review(oid, inline=0, body="", when="2026-01-01T00:00:00Z",
+           login="copilot-pull-request-reviewer"):
+    return {"author": {"login": login}, "submittedAt": when,
+            "commit": {"oid": oid}, "comments": {"totalCount": inline},
+            "body": body}
+
+
+class ClassificationTests(unittest.TestCase):
+    """Every path that decides whether the loop terminates."""
+
+    def _run(self):
+        argv = sys.argv
+        sys.argv = ["copilot-signals.py", "owner", "repo", "1"]
+        try:
+            return signals.main()
+        finally:
+            sys.argv = argv
+
+    def assertVerdict(self, reviews, expected, head=HEAD):
+        signals.fetch = lambda owner, repo, number: {
+            "headRefOid": head,
+            "reviewRequests": {"nodes": []},
+            "reviews": {"nodes": reviews},
+        }
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(self._run(), expected)
+
+    def test_no_review_at_head_is_not_applicable(self):
+        """The silent-abandonment trap. Never read this as clean."""
+        self.assertVerdict([review(OLD, inline=3, body=SUPPRESSED_TWO)],
+                           signals.NOT_APPLICABLE)
+
+    def test_no_reviews_at_all_is_not_applicable(self):
+        self.assertVerdict([], signals.NOT_APPLICABLE)
+
+    def test_clean_review_at_head(self):
+        self.assertVerdict([review(HEAD)], signals.CLEAN)
+
+    def test_benign_details_block_is_not_suppressed_findings(self):
+        self.assertVerdict([review(HEAD, body=BENIGN)], signals.CLEAN)
+
+    def test_block_declaring_zero_and_carrying_none_is_clean(self):
+        self.assertVerdict([review(HEAD, body=SUPPRESSED_EMPTY)], signals.CLEAN)
+
+    def test_inline_comments_require_triage(self):
+        self.assertVerdict([review(HEAD, inline=2)], signals.TRIAGE_REQUIRED)
+
+    def test_suppressed_findings_require_triage(self):
+        """The whole reason the signal exists: zero inline, real findings."""
+        self.assertVerdict([review(HEAD, body=SUPPRESSED_TWO)], signals.TRIAGE_REQUIRED)
+
+    def test_block_declaring_zero_while_carrying_findings_requires_triage(self):
+        """A silent zero is the assertive form of the failure this signal prevents."""
+        self.assertVerdict([review(HEAD, body=SUPPRESSED_ZERO_WITH_FINDINGS)],
+                           signals.TRIAGE_REQUIRED)
+
+    def test_undeclared_count_requires_triage(self):
+        self.assertVerdict([review(HEAD, body=SUPPRESSED_UNDECLARED)],
+                           signals.TRIAGE_REQUIRED)
+
+    def test_older_label_variant_requires_triage(self):
+        self.assertVerdict([review(HEAD, body=OLD_LABEL)], signals.TRIAGE_REQUIRED)
+
+    def test_author_review_artifacts_are_not_verdicts(self):
+        """Our own :zap: thread replies create empty COMMENTED reviews."""
+        self.assertVerdict([review(HEAD, login="dgowrie", body=SUPPRESSED_TWO)],
+                           signals.NOT_APPLICABLE)
+
+    def test_latest_review_at_head_wins_when_listed_oldest_first(self):
+        self.assertVerdict(
+            [review(HEAD, body=SUPPRESSED_TWO, when="2026-01-01T00:00:00Z"),
+             review(HEAD, when="2026-01-02T00:00:00Z")], signals.CLEAN)
+
+    def test_latest_review_at_head_wins_when_listed_newest_first(self):
+        """PullRequest.reviews takes no orderBy, so neither order may be assumed."""
+        self.assertVerdict(
+            [review(HEAD, when="2026-01-02T00:00:00Z"),
+             review(HEAD, body=SUPPRESSED_TWO, when="2026-01-01T00:00:00Z")],
+            signals.CLEAN)
+
+    def test_stale_clean_review_does_not_override_newer_dirty_one(self):
+        self.assertVerdict(
+            [review(HEAD, when="2026-01-01T00:00:00Z"),
+             review(HEAD, body=SUPPRESSED_TWO, when="2026-01-02T00:00:00Z")],
+            signals.TRIAGE_REQUIRED)
+
+    def test_historical_suppressed_block_does_not_keep_the_loop_dirty(self):
+        """Head-scoping. Without it an already-fixed round never reaches clean."""
+        self.assertVerdict(
+            [review(OLD, body=SUPPRESSED_TWO), review(HEAD)], signals.CLEAN)
+
+
+class ParserTests(unittest.TestCase):
+    def test_matches_both_observed_labels(self):
+        for body, expected in ((SUPPRESSED_TWO, 2), (OLD_LABEL, 3)):
+            with self.subTest(body=body[:40]):
+                count, _, labels = signals.parse_suppressed(body)
+                self.assertEqual(count, expected)
+                self.assertTrue(labels)
+
+    def test_ignores_benign_details_block(self):
+        count, findings, labels = signals.parse_suppressed(BENIGN)
+        self.assertIsNone(count)
+        self.assertEqual(findings, [])
+        self.assertEqual(labels, [])
+
+    def test_unparsable_count_is_none_not_zero(self):
+        count, findings, labels = signals.parse_suppressed(SUPPRESSED_UNDECLARED)
+        self.assertIsNone(count)
+        self.assertTrue(labels)
+        self.assertEqual(len(findings), 1)
+
+    def test_extracts_file_and_text_per_finding(self):
+        _, findings, _ = signals.parse_suppressed(SUPPRESSED_TWO)
+        self.assertEqual([path for path, _ in findings], ["src/a.py", "src/b.py"])
+
+    def test_suppressed_and_benign_blocks_coexist(self):
+        count, findings, _ = signals.parse_suppressed(BENIGN + "\n" + SUPPRESSED_TWO)
+        self.assertEqual(count, 2)
+        self.assertEqual(len(findings), 2)
+
+
+class ArgumentTests(unittest.TestCase):
+    def run_script(self, *args):
+        return subprocess.run(["python3", str(SCRIPT), *args],
+                              capture_output=True, text=True).returncode
+
+    def test_no_arguments_is_error(self):
+        self.assertEqual(self.run_script(), signals.ERROR)
+
+    def test_non_integer_pr_number_is_error(self):
+        """Never let a bad argument land on a verdict exit code."""
+        self.assertEqual(self.run_script("owner", "repo", "abc"), signals.ERROR)
+
+
+@unittest.skipUnless(os.environ.get("SIGNALS_LIVE"), "needs network and gh auth")
+class LiveTests(unittest.TestCase):
+    """Known-answer cases against merged PRs, whose state cannot drift."""
+
+    def run_script(self, number):
+        return subprocess.run(
+            ["python3", str(SCRIPT), "dgowrie", "claude-workflows", str(number)],
+            capture_output=True, text=True)
+
+    def test_pr_72_has_no_review_at_head(self):
+        """Merged with its last review two commits back."""
+        self.assertEqual(self.run_script(72).returncode, signals.NOT_APPLICABLE)
+
+    def test_pr_72_reproduces_both_label_variants(self):
+        out = self.run_script(72).stdout
+        self.assertIn("Comments suppressed due to low confidence (1)", out)
+        self.assertIn("Suppressed comments (4)", out)
+
+    def test_pr_81_is_clean_at_head(self):
+        self.assertEqual(self.run_script(81).returncode, signals.CLEAN)
+
+    def test_unknown_repo_is_error(self):
+        result = subprocess.run(
+            ["python3", str(SCRIPT), "dgowrie", "no-such-repo-xyz", "1"],
+            capture_output=True, text=True)
+        self.assertEqual(result.returncode, signals.ERROR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/pr-review-bot-loop/scripts/test_copilot_signals.py
+++ b/skills/pr-review-bot-loop/scripts/test_copilot_signals.py
@@ -68,12 +68,14 @@ def review(oid, inline=0, body="", when="2026-01-01T00:00:00Z",
 
 
 def payload(reviews, head=HEAD, pending=()):
+    """`pending` takes logins, or (login, __typename) pairs to vary the type."""
+    nodes = []
+    for entry in pending:
+        login, typename = entry if isinstance(entry, tuple) else (entry, "Bot")
+        nodes.append({"requestedReviewer": {"__typename": typename, "login": login}})
     return {
         "headRefOid": head,
-        "reviewRequests": {"nodes": [
-            {"requestedReviewer": {"__typename": "Bot", "login": login}}
-            for login in pending
-        ]},
+        "reviewRequests": {"nodes": nodes},
         "reviews": {"nodes": reviews},
     }
 
@@ -225,6 +227,21 @@ class ReportTests(unittest.TestCase):
     def test_non_copilot_requested_reviewer_is_not_reported_as_pending(self):
         self.assertIn("pending none",
                       self.report([review(HEAD)], pending=["some-human"]))
+
+    def test_human_reviewer_named_like_the_bot_is_not_reported_as_pending(self):
+        """Login alone is not enough; a User reading as pending parks the loop.
+
+        Requesting a human whose login contains "copilot" would otherwise send
+        step 2 into wait instead of re-requesting, with nothing ever landing.
+        """
+        self.assertIn("pending none",
+                      self.report([review(HEAD)], pending=[("copilotfan", "User")]))
+
+    def test_bot_request_is_still_reported_when_a_human_lookalike_coexists(self):
+        out = self.report([review(HEAD)], pending=[
+            ("copilotfan", "User"), ("copilot-pull-request-reviewer", "Bot")])
+        self.assertIn("copilot-pull-request-reviewer", out)
+        self.assertNotIn("copilotfan", out)
 
     def test_reports_head_and_each_review(self):
         out = self.report([review(OLD), review(HEAD, inline=2)])


### PR DESCRIPTION
Third slice of #69, sibling to `/pr-review-adversarial` (#82). Adds
`skills/pr-review-bot-loop/`, its symlink, and the README entry.

## What this is

A self-paced loop that drives **your own** PR to a state where the automated reviewer has nothing
left to say, so a human reviewer spends attention on design rather than on what a bot would have
caught. It had been run by hand across three worked examples; this encodes it.

Self-review only, and it stops at a readiness report. Merge gating belongs to #69's next slice, the
`/pr-review` self-review mode that calls this loop.

## The signal that makes it non-trivial

Copilot withholds low-confidence findings into a collapsed `<details>` block in the review **body**.
They never become inline comments, so `comments.totalCount`, the "generated no new comments" body
text, and a post-`submittedAt` thread count all report clean while real defects sit unread. On one
5-round PR, **6 of 11 fix commits came from reviews that all three clean signals called clean**,
including a rendering bug and a regression introduced one round earlier.

So the adapter contract is five signals, not four, and the fifth is three-state rather than boolean:

| State | Condition | Loop action |
| --- | --- | --- |
| clean | review at head, nothing posted and nothing suppressed | terminate |
| triage-required | review at head, suppressed count non-zero or unparsable | triage, fix, push, re-request |
| not-applicable | no review at head | re-request, or wait if one is pending |

Collapsing the third state is a bug in opposite directions. Scoping the check to the review at head
is required, or an already-fixed round's block keeps the loop dirty forever; head-scoping alone then
makes "no review at head" indistinguishable from clean, which is the silent-abandonment trap.

## Reading order

1. `skills/pr-review-bot-loop/SKILL.md` - the contract, the loop, the traps.
2. `skills/pr-review-bot-loop/scripts/copilot-signals.py` - the `landed?` + `suppressed?` detector,
   about 180 lines. It ships as a script rather than prose because a hand-rolled version of it was
   measured wrong twice; precedent is `work-next-task/scripts/ralph.sh`.
3. `README.md` - one added line.

## Validation

No lint or test tooling in this repo, so validated manually: frontmatter parses (two keys, folded
description), MD060 pipe spacing clean, no em/en dash or horizontal bar in either new file or the
added README line, symlink created (it dangles until this merges and the main checkout is pulled,
which is expected).

The detector was validated against PRs in this repo whose answers were already known, and across a
state transition rather than at a single point, since two of its four traps only appear after a
previous one is fixed:

| Case | Expected | Result |
| --- | --- | --- |
| #72 (6 reviews, both suppressed label variants, no review at head) | reproduces 1/1/1/4/2/1, exit 2 | pass |
| #81 (clean review at head) | exit 0 | pass |
| #82 pinned back to `e7c51e8` (suppressed at head) | exit 1 | pass |
| unknown repo / no args | exit 3, no verdict | pass |

## Frontmatter

`name` and `description` only. Per `CLAUDE.md` the no-op `user-invocable` field is omitted, which
deviates from the 17 existing skills that still carry it; #86 tracks stripping it from those. Model
invocation stays on because #69's next slice invokes this skill by name.

Part of #69.
