### PR TITLE
docs(internals): ground memory-context-management in verified constants

### DIFF
--- a/internals/claude-code-internals-cheatsheet.md
+++ b/internals/claude-code-internals-cheatsheet.md
@@ -63,7 +63,7 @@ A practical guide to how Claude Code manages state, memory, and context across s
 | **Scoping** | Project-directory-scoped. Global lessons need CLAUDE.md, not memory |
 | **Staleness** | No expiry or auto-cleanup. Shipped project memories become dead weight |
 | **Conflicts** | A memory can contradict CLAUDE.md or another memory. No resolution mechanism |
-| **Truncation** | MEMORY.md index is capped at both 200 lines and 25KB; the byte cap usually binds first ([detail](memory-context-management.md)) |
+| **Truncation** | MEMORY.md index is capped at both 200 lines and 25KB; the byte cap binds first above ~125 chars per entry ([detail](memory-context-management.md)) |
 | **Best-effort** | Claude is instructed to read/write memories, but there's no guarantee it does |
 
 ### Maintenance habits

--- a/internals/claude-code-internals-cheatsheet.md
+++ b/internals/claude-code-internals-cheatsheet.md
@@ -63,7 +63,7 @@ A practical guide to how Claude Code manages state, memory, and context across s
 | **Scoping** | Project-directory-scoped. Global lessons need CLAUDE.md, not memory |
 | **Staleness** | No expiry or auto-cleanup. Shipped project memories become dead weight |
 | **Conflicts** | A memory can contradict CLAUDE.md or another memory. No resolution mechanism |
-| **Truncation** | MEMORY.md index truncates past 200 lines |
+| **Truncation** | MEMORY.md index is capped at both 200 lines and 25KB; the byte cap usually binds first ([detail](memory-context-management.md)) |
 | **Best-effort** | Claude is instructed to read/write memories, but there's no guarantee it does |
 
 ### Maintenance habits

--- a/internals/claude-code-internals-presentation.html
+++ b/internals/claude-code-internals-presentation.html
@@ -144,7 +144,7 @@
       <tr><td>Scoping</td><td>Project-directory-scoped. Global lessons need <code>CLAUDE.md</code></td></tr>
       <tr><td>Staleness</td><td>No expiry or auto-cleanup</td></tr>
       <tr><td>Conflicts</td><td>Can contradict CLAUDE.md or other memories</td></tr>
-      <tr><td>Truncation</td><td>Index truncates past 200 lines</td></tr>
+      <tr><td>Truncation</td><td>Index capped at 200 lines <em>and</em> 25KB; the byte cap usually binds first</td></tr>
       <tr><td>Best-effort</td><td>No guarantee Claude reads or writes them</td></tr>
     </table>
   </section>

--- a/internals/claude-code-internals-presentation.html
+++ b/internals/claude-code-internals-presentation.html
@@ -144,7 +144,7 @@
       <tr><td>Scoping</td><td>Project-directory-scoped. Global lessons need <code>CLAUDE.md</code></td></tr>
       <tr><td>Staleness</td><td>No expiry or auto-cleanup</td></tr>
       <tr><td>Conflicts</td><td>Can contradict CLAUDE.md or other memories</td></tr>
-      <tr><td>Truncation</td><td>Index capped at 200 lines <em>and</em> 25KB; the byte cap usually binds first</td></tr>
+      <tr><td>Truncation</td><td>Index capped at 200 lines <em>and</em> 25KB; byte cap binds first above ~125 chars per entry</td></tr>
       <tr><td>Best-effort</td><td>No guarantee Claude reads or writes them</td></tr>
     </table>
   </section>

--- a/internals/memory-context-management.md
+++ b/internals/memory-context-management.md
@@ -18,9 +18,11 @@ It is not the session's only always-loaded context. The CLAUDE.md hierarchy (glo
 - **25,000-byte cap** on the spliced index, checked independently of the line cap
 - At ~150 chars per line, a full index is roughly 7-10K tokens
 
-At that average line length the byte cap binds first: 200 lines x 150 chars is ~30KB, past the 25KB budget. Treat 25KB, not 200 entries, as the practical ceiling.
+The two caps cross at 125 chars per entry (25,000 / 200). Above that average the byte cap binds first and the line cap is never reached; below it, the reverse. That break-even is arithmetic on the two verified constants, so it holds whatever the real average turns out to be.
 
-> **Provenance.** The two caps above were read out of the Claude Code binary at v2.1.226 (checked 2026-08-07): the truncation notice Claude receives is templated from a `lineCap` constant of 200, and the index size warning uses a `spliceCap` of 25000 bytes. Everything else on this page (the ~150 chars/line average, the token figures, the scaling table's experience column) is estimate, not measurement. Re-check the constants when Claude Code minor versions move.
+Measured against the memory indexes on this machine (13 entries across all projects, mean 188.5 chars, max 264), the byte cap binds first with roughly 1.5x margin, so 25KB is the ceiling that matters here. That is one small corpus, not a general result. Compare your own index against the 125 break-even rather than inheriting the number.
+
+> **Provenance.** The two caps above were read out of the Claude Code binary at v2.1.226 (checked 2026-08-07): the truncation notice Claude receives is templated from a `lineCap` constant of 200, and the index size warning uses a `spliceCap` of 25000 bytes. Everything else on this page (the ~150 chars/line average, the token figures, the scaling table's experience column) is estimate, not measurement. The 125-char break-even is derived from the two constants rather than estimated, so it carries their confidence; the 188.5-char mean is a measurement of one machine's indexes, not a general figure. Re-check the constants when Claude Code minor versions move.
 
 ### Tier 2: Loaded on demand
 

--- a/internals/memory-context-management.md
+++ b/internals/memory-context-management.md
@@ -10,7 +10,9 @@ Memory uses a cheap-index, expensive-payload design.
 
 ### Tier 1: Always loaded
 
-`MEMORY.md` (the index) is injected into every session's context automatically. Each entry is a one-line summary (~150 chars). This is the only guaranteed token cost per session.
+`MEMORY.md` (the index) is injected into every session's context automatically. Each entry is a one-line summary (~150 chars). This is the memory system's only guaranteed token cost per session.
+
+It is not the session's only always-loaded context. The CLAUDE.md hierarchy (global, project, local), every file in `~/.claude/rules/`, and the description of every model-invocable skill all load unconditionally, and together they typically outweigh the index. This page scopes to memory; budget the rest separately.
 
 - **200-line hard cap** — lines beyond 200 are truncated and invisible to Claude
 - **25,000-byte cap** on the spliced index, checked independently of the line cap
@@ -62,7 +64,7 @@ They're the only thing Claude sees before deciding to read or skip. Quality here
 
 - Aim for under 1KB per memory file — enough for context, not a full document
 - If a memory exceeds 2KB, consider whether it should be a plan or repo document instead
-- The React 19 upgrade plan memory (4.6KB) is an example of something better suited to the `claude-workflows` repo
+- This page is the worked example: several KB of reasoning, so it lives here as a repo document, while the sub-1KB `config/rules/memory-hygiene.md` carries the directive that actually loads into sessions
 
 ### Scaling expectations
 

--- a/internals/memory-context-management.md
+++ b/internals/memory-context-management.md
@@ -12,8 +12,13 @@ Memory uses a cheap-index, expensive-payload design.
 
 `MEMORY.md` (the index) is injected into every session's context automatically. Each entry is a one-line summary (~150 chars). This is the only guaranteed token cost per session.
 
-- 200-line hard cap — lines beyond 200 are truncated and invisible to Claude
+- **200-line hard cap** — lines beyond 200 are truncated and invisible to Claude
+- **25,000-byte cap** on the spliced index, checked independently of the line cap
 - At ~150 chars per line, a full index is roughly 7-10K tokens
+
+At that average line length the byte cap binds first: 200 lines x 150 chars is ~30KB, past the 25KB budget. Treat 25KB, not 200 entries, as the practical ceiling.
+
+> **Provenance.** The two caps above were read out of the Claude Code binary at v2.1.226 (checked 2026-08-07): the truncation notice Claude receives is templated from a `lineCap` constant of 200, and the index size warning uses a `spliceCap` of 25000 bytes. Everything else on this page (the ~150 chars/line average, the token figures, the scaling table's experience column) is estimate, not measurement. Re-check the constants when Claude Code minor versions move.
 
 ### Tier 2: Loaded on demand
 
@@ -68,3 +73,19 @@ They're the only thing Claude sees before deciding to read or skip. Quality here
 | 50-100 | Notable (~7-15K tokens) | Noisier signals, more false reads |
 | 100-200 | Significant (~15-30K tokens) | Approaching the cap, pruning essential |
 | 200+ | Truncated | Entries beyond 200 are invisible |
+
+(Row boundaries are line-count based; the 25KB byte cap can bite earlier if descriptions run long.)
+
+---
+
+## Derived artifacts
+
+This page is the rationale source for three things that encode its numbers. Change a threshold here and update all three:
+
+| Artifact | What it inherits |
+| --- | --- |
+| [`config/rules/memory-hygiene.md`](../config/rules/memory-hygiene.md) | The 1KB / 2KB file sizing, prune-and-dedupe posture, index description quality bar |
+| [`config/rules/memory-session-exit.md`](../config/rules/memory-session-exit.md) | The staleness and consolidation checks, driven by index bloat cost |
+| [`skills/memory-audit/SKILL.md`](../skills/memory-audit/SKILL.md) | The audit procedure; its stated goal is keeping the two-tier system efficient |
+
+Both rules are symlinked into `~/.claude/rules/` and load into every session, so they carry the directives without the reasoning. The reasoning lives here.


### PR DESCRIPTION
## Summary

`internals/memory-context-management.md` is the rationale source for two always-loaded rules (`memory-hygiene`, `memory-session-exit`) and the `/memory-audit` skill, but its load-bearing numbers were asserted without provenance and two of its claims had gone false. This grounds the constants in the shipped binary, documents a cap the page was missing, and makes the dependency chain explicit in both directions.

## What changed

**Verified the caps** (`c94918b`). The 200-line index cap was correct: `w7=200` is declared beside `X_="MEMORY.md"` in the Claude Code binary at v2.1.226, passed as `lineCap`, and templated into the truncation notice Claude receives. Recorded with version and check date. The surrounding figures (~150 chars/line, token columns, the scaling table's experience column) have no such backing, so the provenance note says so explicitly rather than letting them borrow credibility from the verified numbers.

**Documented a second cap** (`c94918b`). `spliceCap = 25000` bytes is checked on the index independently of the line cap. This matters because at the page's own ~150 chars/line assumption, 200 lines is ~30KB, so the byte cap binds first. The page's headline advice ("the cap is 200 entries") was optimistic.

**Added a Derived artifacts footer** (`c94918b`) naming the two rules and the skill that inherit these thresholds, so a change here surfaces the three places encoding it. Previously the link ran one way through the README only.

**Corrected two false claims** (`66f783c`):

- Line 13 said the memory index is "the only guaranteed token cost per session". The CLAUDE.md hierarchy, every file in `~/.claude/rules/`, and every model-invocable skill description also load unconditionally and outweigh it. The claim also contradicted the footer added in the first commit.
- The file-sizing section's only concrete example of the over-2KB rule cited "the React 19 upgrade plan memory (4.6KB)". That memory no longer exists in any project memory directory, and it lived outside this repo, so no reader could verify it. Replaced with a self-referential example that stays checkable.

## Review notes

Read `c94918b` then `66f783c`; the second depends on the footer the first adds.

Sizes are given in magnitude rather than exact KB deliberately. I first wrote "~4.6KB" for this page, which was accurate when measured and stale by the time it saved, because the edits in the same commit grew the file. That is precisely how the React 19 line rotted, so prose sizes are now written so they cannot drift out of sync with the file.

## Known gaps, not addressed

Neither propagates into the rules, so both were left out of scope:

- Lines 57 and 59 reference `#607`, `#652`, `#474` from another repo. Unresolvable here, but purely illustrative; the Bad/Good contrast survives without resolving them.
- The title promises "Memory & Context Management" while the content covers only the auto-memory subsystem. Compaction, the CLAUDE.md hierarchy, and rules cost are named but not budgeted.

## Verification caveat

`spliceCap` enforcement is inferred, not verified. It is unambiguously a 25000-byte budget used in the index size-warning path, but whether overflow truncates the way the line cap does or only warns was not confirmed. The wording in the doc stays inside what was checked.
