### PR TITLE
fix(skills): scope pr-review-batching trigger to the offer boundary

### DIFF
--- a/skills/pr-review-batching/SKILL.md
+++ b/skills/pr-review-batching/SKILL.md
@@ -2,24 +2,32 @@
 name: pr-review-batching
 user-invocable: true
 description: >
-  Stages PR review comments as drafts on a GitHub pending review; never publishes. Owns two
-  operations: (1) ensure-then-append, which adds comments to an existing pending review or
-  creates one if none exists, without clobbering user-in-flight edits; (2) incident response,
-  which undoes an accidentally published review by deleting its visible comments and
-  recreating as pending.
+  Owns the submission lifecycle for PR review comments. Three operations: (1) ensure-then-append,
+  which stages NEW inline comments as drafts on a pending review, creating one if none exists,
+  without clobbering user-in-flight edits; (2) incident response, which undoes an accidentally
+  published review by deleting its visible comments and recreating as pending; (3) replies to
+  EXISTING review threads, which cannot be staged at all, because the replies endpoint publishes
+  on send and the pending-review endpoint rejects `in_reply_to`; those require the user's explicit
+  confirmation before posting.
 
-  ACTION-BOUNDARY TRIGGER: consult this skill before any `gh pr review` invocation or any
-  POST / DELETE on `/pulls/{n}/reviews`. This skill is the guard against publishing a review
-  when the user wanted drafts. Also triggers on phrases: "draft comment", "pending review",
-  "post this as a draft", "add to the review", "stage as a draft", or explicit
+  ACTION-BOUNDARY TRIGGER: consult this skill before any `gh pr review` invocation, before any
+  POST / DELETE on `/pulls/{n}/reviews`, and before OFFERING OR PROMISING a draft, staged, or
+  pending path for PR feedback. The offer boundary matters as much as the execution one: checking
+  only at execution time is too late to avoid promising a staging flow that does not exist for
+  thread replies. Also triggers on phrases: "draft comment", "pending review", "post this as a
+  draft", "add to the review", "stage as a draft", "reply to the review comments", or explicit
   `/pr-review-batching`.
 ---
 
 # PR Review Batching
 
-This skill owns the submission lifecycle for PR review comments. Every comment is staged as a
-draft on a pending review; the user submits manually. Claude never sets `event=COMMENT`,
-`event=APPROVE`, or `event=REQUEST_CHANGES`.
+This skill owns the submission lifecycle for PR review comments. Every *new inline comment* is
+staged as a draft on a pending review; the user submits manually. Claude never sets
+`event=COMMENT`, `event=APPROVE`, or `event=REQUEST_CHANGES`.
+
+Replies to *existing* review threads are the exception: GitHub offers no draft path for them
+(see Operation 3). Never offer to stage a thread reply. Check which kind of comment is in play
+before describing the flow to the user, not just before executing it.
 
 Documented user convention (global `CLAUDE.md`):
 


### PR DESCRIPTION
## Summary

`pr-review-batching` is the guard against publishing PR feedback when the user wanted drafts. Its ACTION-BOUNDARY TRIGGER fired only on execution, so it could not prevent *offering* a flow that does not exist. This extends the trigger to the offer boundary and corrects a description that had drifted out of sync with the file.

## What happened

On #88 I offered twice to "stage these replies for your review rather than post directly", replying to Copilot review threads. There is no such path: `POST /pulls/{n}/comments/{id}/replies` publishes on send, and the pending-review endpoint rejects `in_reply_to` with a 422. Operation 3 of this skill already documents that.

The skill caught it, but only because the user's next instruction was "stage the replies", which routed through the skill's phrase trigger. Had they said "post them", the wrong offer would have stood uncorrected and the drafts would simply never have appeared.

## Changes

**Trigger now covers the offer boundary.** Previously `gh pr review` invocations and POST / DELETE on `/reviews`. Now also before offering or promising a draft, staged, or pending path for PR feedback, with the reason stated inline so it is not read as boilerplate.

**Description said "two operations".** The file has had three since Operation 3 was added. It also opened with "never publishes", which is the opposite of what Operation 3 prescribes, and drew no distinction between new inline comments (stageable) and thread replies (not).

**Body intro carried the same overreach.** "Every comment is staged as a draft" is false for Operation 3; now scoped to new inline comments, with the exception stated immediately.

## Why the description mattered

The description is what Claude sees when deciding whether to load the skill. This one advertised staging and disclaimed publishing, which is exactly the wrong prior for thread replies. I am not claiming that caused the error, since I did not consult the skill before offering either way, but a description that contradicts Operation 3 makes the mistake more likely, not less.

## Notes for review

Frontmatter-and-prose only; no procedural steps changed. Operations 1, 2, and 3 are untouched.

Per the known worktree gotcha, `~/.claude/skills/pr-review-batching` symlinks to the main checkout, so the live skill keeps the old description until this merges.

Unrelated to #88, which is docs work on `internals/`. Split out deliberately.
