### PR TITLE
feat(skills): add /pickup, the receiving end of /handoff

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,25 +1,29 @@
 name: tests
 
-# Runs the pr-review-bot-loop detector's tests, whose exit codes decide whether
-# a review loop terminates. Other executable logic in the repo is not covered
-# here: config/hooks/ has its own test script (block-em-dash.test.sh) that
-# nothing runs automatically, and work-next-task/scripts/ralph.sh has no tests.
+# Runs the tests for the repo's decision-making scripts: the pr-review-bot-loop
+# detector, whose exit codes decide whether a review loop terminates, and the
+# pickup preflight, whose exit code decides whether an unattended run starts at
+# all. Other executable logic in the repo is not covered here: config/hooks/ has
+# its own test script (block-em-dash.test.sh) that nothing runs automatically,
+# and work-next-task/scripts/ralph.sh has no tests.
 
 on:
   pull_request:
     paths:
-      # Matches exactly what the run step discovers. A broader trigger would
+      # Matches exactly what the run steps discover. A broader trigger would
       # give a future skill's script a green run that tested nothing, which
       # reads as coverage; add that skill's directory here instead.
       - 'skills/pr-review-bot-loop/scripts/**'
+      - 'skills/pickup/scripts/**'
       - '.github/workflows/tests.yml'
   push:
     branches: [main]
     paths:
-      # Matches exactly what the run step discovers. A broader trigger would
+      # Matches exactly what the run steps discover. A broader trigger would
       # give a future skill's script a green run that tested nothing, which
       # reads as coverage; add that skill's directory here instead.
       - 'skills/pr-review-bot-loop/scripts/**'
+      - 'skills/pickup/scripts/**'
       - '.github/workflows/tests.yml'
   workflow_dispatch:
 
@@ -43,3 +47,6 @@ jobs:
       # Offline cases only. The SIGNALS_LIVE half asserts against real PRs
       # through the API, which is a pre-push check rather than a CI gate.
       - run: python3 -m unittest discover -s skills/pr-review-bot-loop/scripts -v
+      # Fully offline. The fixtures build throwaway repositories with an inline
+      # identity and signing disabled, so the runner needs no git configuration.
+      - run: python3 -m unittest discover -s skills/pickup/scripts -v

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Changes to a skill file in the repo are immediately live — no copy or sync ste
 - [`/domain-modeling`](skills/domain-modeling/SKILL.md) - build and sharpen a project's domain model (`CONTEXT.md` glossary, `docs/adr/` decisions); companion to `/improve-codebase-architecture`
 - [`/grilling`](skills/grilling/SKILL.md) - Matt Pocock's decision-tree grilling loop, kept distinct from the customized `/grill-me` so `/improve-codebase-architecture` can call it by name
 - [`/writing-for-agents`](skills/writing-for-agents/SKILL.md) - Matt Pocock's reference for writing any document an agent consumes (skills, `AGENTS.md`, `CLAUDE.md`): context pointers, the two loads, information hierarchy, leading words, pruning. Copied verbatim from [mattpocock/skills](https://github.com/mattpocock/skills/tree/main/skills/productivity/writing-for-agents); model-invoked, so it fires on its own when you edit a skill or `CLAUDE.md`
+- [`/handoff`](skills/handoff/SKILL.md) - compact the current session into a handoff document a fresh session can pick up
+- [`/pickup`](skills/pickup/SKILL.md) - the other end of `/handoff`: triage a handoff document, then implement, validate, and drive the review cycle to a reviewed PR. Three modes (`afk`, `semi`, `hitl`); hard-stops on a blocker and halts on a mode mismatch. Ships with `scripts/preflight.py`
 
 ### Rules
 

--- a/skills/pickup/SKILL.md
+++ b/skills/pickup/SKILL.md
@@ -54,7 +54,7 @@ Phase 1 is done when the branch is a feature branch and its name has been printe
 4. Update the description at every phase boundary from here on.
 5. For each judgment call, build the reversible option, add its Decisions Log row, and leave a `:notebook:` inline comment where the decision shows up in the diff.
 
-Phase 2 is done when every acceptance criteria row carries evidence or is explicitly marked unverified.
+Phase 2 is done when every acceptance criterion carries evidence or is explicitly marked unverified.
 
 ## Phase 3: Validate
 

--- a/skills/pickup/SKILL.md
+++ b/skills/pickup/SKILL.md
@@ -27,7 +27,13 @@ The mode is the second argument, defaulting to `afk`.
 
 ## Phase 0: Triage
 
-1. Run `scripts/preflight.py --handoff-doc <path> --cwd <repo>` outside the sandbox. Keep the JSON; later phases reuse it.
+1. Run the preflight script outside the sandbox, from the target project's directory. Keep the JSON; later phases reuse it.
+
+   ```bash
+   ~/.claude/skills/pickup/scripts/preflight.py --handoff-doc <path> --cwd <repo>
+   ```
+
+   That installed path is the one to use. A run happens in the project the handoff document describes, which is almost never this repo, so a repo-relative path resolves to nothing.
 2. On exit 1, print each blocker with its detail and stop. This holds in every mode, and `--force` does not reach it.
 3. Read the handoff document and every issue, PR, and file it references.
 4. Build the acceptance criteria table, fixing each criterion's verification method now, while the work still looks easy.

--- a/skills/pickup/SKILL.md
+++ b/skills/pickup/SKILL.md
@@ -25,6 +25,8 @@ The mode is the second argument, defaulting to `afk`.
 
 `hitl` is interactive only until triage clears. After that it runs like `afk`.
 
+For the mode gate, strictness runs `afk` < `semi` < `hitl`. The order is by how much the human sees before implementation starts, which is what the gate protects: `hitl` resolves every open question with the human first, `semi` shows them the triage and its batches, `afk` shows them nothing until there is a PR.
+
 ## Phase 0: Triage
 
 1. Run the preflight script outside the sandbox, from the target project's directory. Keep the JSON; later phases reuse it.
@@ -34,21 +36,21 @@ The mode is the second argument, defaulting to `afk`.
    ```
 
    That installed path is the one to use. A run happens in the project the handoff document describes, which is almost never this repo, so a repo-relative path resolves to nothing.
-2. On exit 1, print each blocker with its detail and stop. This holds in every mode, and `--force` does not reach it.
-3. Read the handoff document and every issue, PR, and file it references.
-4. Build the acceptance criteria table, fixing each criterion's verification method now, while the work still looks easy.
-5. Classify every open question against the taxonomies in `TRIAGE.md`. A hard blocker stops the run here, printed the same way as a preflight blocker.
-6. Count the user-visible judgment calls and recommend a mode.
-7. Write the triage file.
-8. Apply the mode gate. When the recommended mode is stricter than the requested one, print the mismatch, name the forks that caused it, and stop unless `--force` is present. Then follow the mode's row in the table above.
+2. Write the triage file immediately, carrying the preflight result and any blockers it reported. Every later step updates it in place, and every stop below updates it before stopping, so the run always leaves this artifact behind.
+3. On a non-zero exit, stop. On exit 1 print each blocker with its detail; on any other non-zero exit print the raw output, which covers the usage error and a crash alike. This holds in every mode, and `--force` does not reach it.
+4. Read the handoff document and every issue, PR, and file it references.
+5. Build the acceptance criteria table, fixing each criterion's verification method now, while the work still looks easy.
+6. Classify every open question against the taxonomies in `TRIAGE.md`. A hard blocker stops the run here, printed the same way as a preflight blocker.
+7. Count the user-visible judgment calls and recommend a mode.
+8. Apply the mode gate. When the recommended mode is stricter than the requested one (`afk` < `semi` < `hitl`), print the mismatch, name the forks that caused it, and stop unless `--force` is present. Then follow the mode's row in the table above.
 
-Phase 0 is done when every acceptance criterion carries a verification method, every open question carries a class, the triage file exists, and the mode is settled.
+Phase 0 is done when every acceptance criterion carries a verification method, every open question carries a class, the triage file records the outcome the run actually reached, and the mode is settled.
 
 ## Phase 1: Branch
 
 When preflight reported an existing pull request, this run is a resume: read that PR's description for the state the earlier run reached, and re-enter at the phase its Outstanding section points to.
 
-Otherwise, on the default branch, fetch and branch from `origin/main` as `type/<issue#>-<slug>`, taking the issue from the handoff document and falling back to `type/<slug>` from its title. On a feature branch already, keep it; the handoff most likely came from a session that made it.
+Otherwise, on the default branch, branch as `type/<issue#>-<slug>`, taking the issue from the handoff document and falling back to `type/<slug>` from its title. `type` is the Conventional Commits type matching the work. Branch from `origin/<default_branch>` after fetching when the repo has a remote, and from the local `<default_branch>` when it does not; take `default_branch` from the Phase 0 preflight JSON rather than assuming `main`, since preflight resolves it and repos differ. On a feature branch already, keep it; the handoff most likely came from a session that made it.
 
 Phase 1 is done when the branch is a feature branch and its name has been printed.
 
@@ -86,7 +88,13 @@ Phase 4 is done when a full cycle completes with a clean bot pass and zero new c
 
 ## Phase 5: Hand back
 
-Mark the pull request ready for review. Resolve reviewers by re-running preflight with `--paths` over the changed files and using the CODEOWNERS result, falling back to a reviewer named in the handoff document; when neither yields one, say so rather than guessing at a person. Update the description a final time and print a summary: criteria met, criteria unverified, decisions taken, anything outstanding.
+Mark the pull request ready for review. Resolve reviewers by re-running preflight over the changed files, keeping the arguments from Phase 0 and adding `--paths`:
+
+```bash
+~/.claude/skills/pickup/scripts/preflight.py --handoff-doc <path> --cwd <repo> --paths <changed files>
+```
+
+Phase 5 consumes only the `codeowners` field, so a non-zero exit here is worth printing but does not abort the hand-back: by this point the run's own PR exists and a build artifact left in the tree is enough to report a blocker. Fall back to a reviewer named in the handoff document, and when neither yields one, say so rather than guessing at a person. Update the description a final time and print a summary: criteria met, criteria unverified, decisions taken, anything outstanding.
 
 Phase 5 is done when the pull request is ready for review, a reviewer is requested or their absence is stated, and the summary is printed.
 

--- a/skills/pickup/SKILL.md
+++ b/skills/pickup/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: pickup
+description: Run a handoff document through to a reviewed pull request, attended or unattended.
+argument-hint: "<handoff-doc-path> [afk|semi|hitl] [--force]"
+disable-model-invocation: true
+---
+
+# Pickup
+
+The other end of [`/handoff`](../handoff/SKILL.md). `/handoff` compacts a session into a document; `/pickup` takes that document and drives it to a pull request that a human can review.
+
+Read [`TRIAGE.md`](TRIAGE.md) at Phase 0. It carries the classification taxonomies, the mode thresholds, and every artifact format this file refers to.
+
+Run `gh` and `preflight.py` outside the command sandbox. The sandbox cannot reach the credential keyring, so `gh auth status` exits 1 there and a working install reports as unauthenticated.
+
+## Modes
+
+The mode is the second argument, defaulting to `afk`.
+
+| Mode | At triage | Open questions | At phase boundaries |
+| --- | --- | --- | --- |
+| `afk` | Proceeds | Decided, logged, flagged inline on the PR | Proceeds |
+| `semi` | Stops for review | Decided provisionally, batched | Stops with the batch |
+| `hitl` | Stops; `/grill-me` until every question is resolved, `/prototype` when a fork needs to be seen before it is chosen | Resolved by the human | Proceeds |
+
+`hitl` is interactive only until triage clears. After that it runs like `afk`.
+
+## Phase 0: Triage
+
+1. Run `scripts/preflight.py --handoff-doc <path> --cwd <repo>` outside the sandbox. Keep the JSON; later phases reuse it.
+2. On exit 1, print each blocker with its detail and stop. This holds in every mode, and `--force` does not reach it.
+3. Read the handoff document and every issue, PR, and file it references.
+4. Build the acceptance criteria table, fixing each criterion's verification method now, while the work still looks easy.
+5. Classify every open question against the taxonomies in `TRIAGE.md`. A hard blocker stops the run here, printed the same way as a preflight blocker.
+6. Count the user-visible judgment calls and recommend a mode.
+7. Write the triage file.
+8. Apply the mode gate. When the recommended mode is stricter than the requested one, print the mismatch, name the forks that caused it, and stop unless `--force` is present. Then follow the mode's row in the table above.
+
+Phase 0 is done when every acceptance criterion carries a verification method, every open question carries a class, the triage file exists, and the mode is settled.
+
+## Phase 1: Branch
+
+When preflight reported an existing pull request, this run is a resume: read that PR's description for the state the earlier run reached, and re-enter at the phase its Outstanding section points to.
+
+Otherwise, on the default branch, fetch and branch from `origin/main` as `type/<issue#>-<slug>`, taking the issue from the handoff document and falling back to `type/<slug>` from its title. On a feature branch already, keep it; the handoff most likely came from a session that made it.
+
+Phase 1 is done when the branch is a feature branch and its name has been printed.
+
+## Phase 2: Implement
+
+1. Work criterion by criterion, red first: write the failing test, confirm it fails, then implement to green.
+2. Keep commits discrete, mapping to logical units rather than to time spent.
+3. Open a **draft** pull request as soon as the first commit exists, citing the handoff document's filename in the body. The description is this run's canonical status surface, and it is also how a later run finds this one; opening it early is what makes a resume possible after the session dies.
+4. Update the description at every phase boundary from here on.
+5. For each judgment call, build the reversible option, add its Decisions Log row, and leave a `:notebook:` inline comment where the decision shows up in the diff.
+
+Phase 2 is done when every acceptance criteria row carries evidence or is explicitly marked unverified.
+
+## Phase 3: Validate
+
+Run the full test suite, the typechecker, and the linter, with lint clean meaning zero warnings in touched files. Lint autofix lands as its own commit. Push, then wait for CI: CI is authoritative, and local green is necessary rather than sufficient.
+
+Phase 3 is done when the suite, typecheck, and lint are green locally and CI is green on the pushed head.
+
+## Phase 4: Review cycle
+
+One cycle is `/pr-review-bot-loop` to a clean pass, then `/pr-review-adversarial`. Fixes from the adversarial pass invalidate the clean bot pass, so a cycle that lands fixes is followed by another cycle.
+
+Route each finding:
+
+| Finding | Action |
+| --- | --- |
+| Confirmed | Fix, commit, reply `:zap: <hash>` |
+| Wrong | Reply `:thought_balloon: <rationale>`, leave the thread open |
+| Real but past the acceptance criteria | Record under Outstanding; raise a follow-up issue when it warrants one |
+
+Cap the run at 3 cycles. On exhaustion, stop, leave the pull request as it stands, and write what remains open and why. A run that reports honestly on an unconverged pull request is worth more than one that keeps grinding or declares victory.
+
+Phase 4 is done when a full cycle completes with a clean bot pass and zero new confirmed findings, or when the third cycle ends.
+
+## Phase 5: Hand back
+
+Mark the pull request ready for review. Resolve reviewers by re-running preflight with `--paths` over the changed files and using the CODEOWNERS result, falling back to a reviewer named in the handoff document; when neither yields one, say so rather than guessing at a person. Update the description a final time and print a summary: criteria met, criteria unverified, decisions taken, anything outstanding.
+
+Phase 5 is done when the pull request is ready for review, a reviewer is requested or their absence is stated, and the summary is printed.
+
+## Mandate
+
+Invoking this skill authorizes it, for this one pull request and this run only, to commit, push, publish review replies, and request a reviewer without asking again. This is a deliberate carve-out: the standing convention is to stage review comments for the human to submit, and an unattended run has nobody to ask.
+
+These stay the human's, in every mode: merging, force-pushing, changing repository visibility, and touching any pull request other than the one this run created.
+
+Notify at exactly four moments, so that a notification always means something happened: a triage hard stop, a mode mismatch halt, cycle-cap exhaustion, and successful completion.

--- a/skills/pickup/TRIAGE.md
+++ b/skills/pickup/TRIAGE.md
@@ -52,7 +52,9 @@ Count the user-visible judgment calls after classification, and note whether the
 
 Three individually cheap forks in one component means the run would be designing that component rather than implementing a specification. The threshold is a starting default, deliberately visible here so it can be corrected once real runs show where it sits wrong.
 
-Triage recommends `afk` or `hitl` and never `semi`. Density measures how ambiguous the handoff document is, while `semi` expresses how much oversight the human wants at phase boundaries; that is a preference brought to the run rather than a property readable from the document. A `semi` run is therefore never subject to a mode mismatch on its own account: apply the table above to decide whether its triage should have been `hitl`.
+Triage recommends `afk` or `hitl` and never `semi`. Density measures how ambiguous the handoff document is, while `semi` expresses how much oversight the human wants at phase boundaries; that is a preference brought to the run rather than a property readable from the document.
+
+A `semi` run is still graded by the same table, using the strictness order in [`SKILL.md`](SKILL.md) (`afk` < `semi` < `hitl`): a `semi` run whose triage scores `hitl` halts as a mode mismatch, and one that scores `afk` proceeds.
 
 When the recommended mode is stricter than the requested mode, the run halts with a mode mismatch and names the forks that caused it. `--force` proceeds anyway. The asymmetry is the point: a blocker means the run cannot know something, while a mismatch means the human probably wants to be present. Only the second is the human's to overrule.
 
@@ -77,7 +79,9 @@ A criterion proven only by tier 3 stays unverified in the summary. Reporting it 
 
 ### Triage file
 
-Written beside the handoff document as `<handoff-basename>.triage.md` before anything else happens, and never rewritten. When that directory is not writable, it goes to the session scratchpad and the run prints the path. This is the one artifact whose value survives a run that never reaches a pull request.
+Written beside the handoff document as `<handoff-basename>.triage.md` as soon as preflight returns, then updated in place as triage proceeds and once more at whatever point the run stops. When that directory is not writable, it goes to the session scratchpad and the run prints the path.
+
+Writing it first is the whole point: this is the one artifact whose value survives a run that never reaches a pull request, and the runs that never reach one are exactly the runs that stop early. A triage file written only at the end of a successful triage would be missing from every blocked run, which is when its `## Blockers` section is the only record of what happened.
 
 ```markdown
 # Triage: <handoff document name>

--- a/skills/pickup/TRIAGE.md
+++ b/skills/pickup/TRIAGE.md
@@ -1,0 +1,125 @@
+# Triage reference
+
+The reference half of [`/pickup`](SKILL.md): how to classify what a handoff document leaves open, and the shape of every artifact a run produces. `SKILL.md` holds the steps.
+
+Triage is the only gate protecting an unattended run. Everything downstream inherits its verdict, so it is graded on being exhaustive rather than on being fast: every acceptance criterion carries a verification method, and every open question carries a class.
+
+## Classifying an open question
+
+Each open question lands in exactly one class. Work down the list and stop at the first match.
+
+### Hard blockers
+
+Stop the run. These hold in every mode, and `--force` does not reach them.
+
+| Blocker | What it looks like |
+| --- | --- |
+| Unreadable input | The handoff document, or an issue, PR, or file it depends on, cannot be read. |
+| Contradiction | The handoff document and its linked issue disagree about an acceptance criterion. |
+| Irreversible or outward-facing | Schema or data migration, public API or contract change, repo visibility, credentials, auth, anything published to an external service. |
+| Expensive to reverse | The decision sets a pattern other code will copy, defines a component's public props, or establishes a layout other views inherit. See the reversibility split below. |
+| Unverifiable criterion | An acceptance criterion with no stated way to prove it and none inferable. A run cannot claim an unmeasurable criterion is met. |
+| Missing access | Credentials absent, a required service down, a repo unreachable. |
+| Dirty tree | Uncommitted or untracked changes of unknown origin. `preflight.py` reports this one. |
+
+`preflight.py` settles unreadable input, missing access, and dirty tree mechanically. The rest are yours to judge, and they are the reason triage is a reading task rather than a script.
+
+### Judgment calls
+
+Decide, record, and continue. Build the reversible way: when options differ in cost to change later, take the cheaper one to undo.
+
+Typical: internal naming, file placement, whether to extract a helper, test structure and granularity, and anything where the options converge on identical user-visible behavior.
+
+Each judgment call earns two records: a row in the Decisions Log, and a `:notebook:` inline comment on the pull request at the line where the decision is visible in the diff. The inline comment is what turns an abstract fork into something reviewable against real code.
+
+### The reversibility split
+
+User-visible divergence alone does not decide the class. Cost to reverse does.
+
+| Cost to reverse | Example | Class |
+| --- | --- | --- |
+| Cheap | Toast against inline warning, empty-state wording, a control disabled against hidden | Judgment call |
+| Expensive | Component prop shape, a layout other views inherit, a pattern the rest of the code will copy | Hard blocker |
+
+## Recommending a mode
+
+Count the user-visible judgment calls after classification, and note whether they cluster on one surface.
+
+| Signal | Recommended mode |
+| --- | --- |
+| Fewer than 3 user-visible judgment calls, none clustered | `afk` |
+| 3 or more, or 2 on the same surface | `hitl` |
+
+Three individually cheap forks in one component means the run would be designing that component rather than implementing a specification. The threshold is a starting default, deliberately visible here so it can be corrected once real runs show where it sits wrong.
+
+When the recommended mode is stricter than the requested mode, the run halts with a mode mismatch and names the forks that caused it. `--force` proceeds anyway. The asymmetry is the point: a blocker means the run cannot know something, while a mismatch means the human probably wants to be present. Only the second is the human's to overrule.
+
+## Acceptance criteria
+
+Every criterion gets a row before any implementation starts, with its verification method fixed while the work still looks easy. Setting the standard up front is what keeps it from sliding once the work turns out to be hard.
+
+| # | Acceptance criterion | Verification method | Evidence |
+| --- | --- | --- | --- |
+| 1 | Card reflows below 480px | Unit test on the breakpoint hook | `FeatureCard.test.tsx:44` |
+| 2 | Warning sits above the fold | Visual | `UNVERIFIED - visual confirmation required` |
+
+Verification methods, in descending preference:
+
+1. **Automated** - a test, a type, a lint rule. Preferred wherever a criterion admits it.
+2. **Observed** - the app driven for real, with a screenshot attached. Reach for this only when the app is already running and reachable; on any failure, fall back to the next tier rather than retrying.
+3. **Visual** - `UNVERIFIED - visual confirmation required`. An honest gap, listed in the pull request so the human knows exactly what to look at.
+
+A criterion proven only by tier 3 stays unverified in the summary. Reporting it as met would make the run's account of itself worthless, which costs far more than the gap does.
+
+## Artifacts
+
+### Triage file
+
+Written beside the handoff document as `<handoff-basename>.triage.md` before anything else happens, and never rewritten. When that directory is not writable, it goes to the session scratchpad and the run prints the path. This is the one artifact whose value survives a run that never reaches a pull request.
+
+```markdown
+# Triage: <handoff document name>
+
+- Mode requested / recommended: afk / afk
+- Preflight: clear (exit 0)
+- Branch: feat/123-feature-card-layout
+
+## Acceptance criteria
+<the table above, Evidence column empty>
+
+## Open questions
+| Question | Class | Resolution |
+| --- | --- | --- |
+| Warning placement | Judgment call (cheap) | Inline; toast is the reversible alternative |
+
+## Blockers
+None.
+```
+
+### Pull request description
+
+The canonical status surface, updated at every phase boundary. It carries the acceptance criteria table with evidence filled in, the Decisions Log, the unverified list, and anything left outstanding. It also cites the handoff document's filename, which is how a later run finds this one and resumes instead of starting over.
+
+```markdown
+Picked up from `handoff-featurecard-layout.md`. Closes #123.
+
+## Acceptance criteria
+<table, Evidence column filled>
+
+## Decisions log
+| Decision | Chosen | Rejected | Why |
+| --- | --- | --- | --- |
+| Warning placement | Inline | Toast | Inline keeps it beside the field it describes; both are one-line changes |
+
+## Unverified
+- AC 2: warning above the fold. Visual confirmation required.
+
+## Outstanding
+None.
+```
+
+An empty section reads `None.` rather than being dropped, so a reader can tell an empty list from a forgotten one.
+
+### Out-of-scope findings
+
+A review finding that is real but reaches past the handoff document's acceptance criteria goes in `Outstanding` and, when it warrants one, becomes a follow-up issue. Widening a pull request beyond its stated criteria is how an unattended run turns a reviewable change into one nobody can review.

--- a/skills/pickup/TRIAGE.md
+++ b/skills/pickup/TRIAGE.md
@@ -52,6 +52,8 @@ Count the user-visible judgment calls after classification, and note whether the
 
 Three individually cheap forks in one component means the run would be designing that component rather than implementing a specification. The threshold is a starting default, deliberately visible here so it can be corrected once real runs show where it sits wrong.
 
+Triage recommends `afk` or `hitl` and never `semi`. Density measures how ambiguous the handoff document is, while `semi` expresses how much oversight the human wants at phase boundaries; that is a preference brought to the run rather than a property readable from the document. A `semi` run is therefore never subject to a mode mismatch on its own account: apply the table above to decide whether its triage should have been `hitl`.
+
 When the recommended mode is stricter than the requested mode, the run halts with a mode mismatch and names the forks that caused it. `--force` proceeds anyway. The asymmetry is the point: a blocker means the run cannot know something, while a mismatch means the human probably wants to be present. Only the second is the human's to overrule.
 
 ## Acceptance criteria

--- a/skills/pickup/scripts/preflight.py
+++ b/skills/pickup/scripts/preflight.py
@@ -22,9 +22,11 @@ script must never look like it has ruled on those.
 Known bounds:
 
 * CODEOWNERS support covers `*`, basename globs (`*.md`), directory prefixes
-  (`skills/`), and anchored paths, with last-match-wins. It does not implement
+  (`skills/`), and anchored paths, with last-match-wins, and wildcards stay
+  inside one path segment as CODEOWNERS specifies. It does not implement
   negation or the full gitignore pattern grammar. An unmatched path contributes
-  no owners rather than a wrong one.
+  no owners rather than a wrong one, and an unreadable CODEOWNERS reports
+  `readable: false` rather than an empty owner list.
 * The default branch is read from `origin/HEAD` when a remote is configured, and
   otherwise inferred from whether `main` or `master` exists locally. A repo whose
   default branch is neither, and which has no remote, reports its current branch.
@@ -117,12 +119,17 @@ def git_facts(cwd):
             "default_branch": None,
             "on_default_branch": False,
             "tree_clean": False,
+            "status_ok": False,
             "dirty_paths": [],
         }
 
     _, branch = run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd)
     branch = branch.strip()
-    _, porcelain = run(["git", "status", "--porcelain"], cwd)
+    # A failed `git status` prints nothing, which is indistinguishable from a
+    # clean tree. Keeping the return code is what stops the dirty-tree gate
+    # from failing open on an unknown tree state.
+    status_code, porcelain = run(["git", "status", "--porcelain"], cwd)
+    status_ok = status_code == 0
     default = _default_branch(cwd)
     dirty = _dirty_paths(porcelain)
     return {
@@ -130,9 +137,27 @@ def git_facts(cwd):
         "current_branch": branch or None,
         "default_branch": default,
         "on_default_branch": bool(branch) and branch == default,
-        "tree_clean": not dirty,
+        "tree_clean": status_ok and not dirty,
+        "status_ok": status_ok,
         "dirty_paths": dirty,
     }
+
+
+def _matches_per_segment(pattern, path):
+    """Glob each path segment separately.
+
+    `fnmatch` on the whole path lets `*` span separators, so `docs/*.md` would
+    match `docs/sub/file.md` and name the wrong owners. Comparing segment by
+    segment confines each wildcard to its own segment.
+    """
+    pattern_parts = pattern.split("/")
+    path_parts = path.split("/")
+    if len(pattern_parts) != len(path_parts):
+        return False
+    return all(
+        fnmatch.fnmatch(path_part, pattern_part)
+        for pattern_part, path_part in zip(pattern_parts, path_parts)
+    )
 
 
 def _codeowners_matches(pattern, path):
@@ -143,7 +168,9 @@ def _codeowners_matches(pattern, path):
         return path.startswith(cleaned)
     if "/" not in cleaned:
         return fnmatch.fnmatch(os.path.basename(path), cleaned)
-    return fnmatch.fnmatch(path, cleaned) or path.startswith(cleaned + "/")
+    if path.startswith(cleaned + "/"):
+        return True
+    return _matches_per_segment(cleaned, path)
 
 
 def codeowners_for(repo_root, paths):
@@ -242,6 +269,12 @@ def collect(cwd, handoff_doc, paths=None):
         blockers.append({
             "code": "not-a-git-repo",
             "detail": "{} is not inside a git repository.".format(cwd),
+        })
+    elif not facts["status_ok"]:
+        blockers.append({
+            "code": "git-status-failed",
+            "detail": "`git status` failed, so the tree state is unknown. "
+                      "A clean-looking empty result cannot be trusted here.",
         })
     elif not facts["tree_clean"]:
         blockers.append({

--- a/skills/pickup/scripts/preflight.py
+++ b/skills/pickup/scripts/preflight.py
@@ -147,7 +147,12 @@ def _codeowners_matches(pattern, path):
 
 
 def codeowners_for(repo_root, paths):
-    """Owners of `paths`, unioned, using last-match-wins per path."""
+    """Owners of `paths`, unioned, using last-match-wins per path.
+
+    `readable` separates "no rule matched" from "the file could not be read".
+    Collapsing the two into an empty owner list is a silent zero: the run would
+    report that nobody owns the code when it had simply failed to look.
+    """
     root = Path(repo_root)
     location = None
     for candidate in CODEOWNERS_LOCATIONS:
@@ -155,10 +160,15 @@ def codeowners_for(repo_root, paths):
             location = candidate
             break
     if location is None:
-        return {"file": None, "owners": []}
+        return {"file": None, "owners": [], "readable": True}
+
+    try:
+        contents = (root / location).read_text()
+    except (OSError, UnicodeDecodeError):
+        return {"file": str(root / location), "owners": [], "readable": False}
 
     rules = []
-    for line in (root / location).read_text().splitlines():
+    for line in contents.splitlines():
         line = line.split("#", 1)[0].strip()
         if not line:
             continue
@@ -177,7 +187,7 @@ def codeowners_for(repo_root, paths):
             if owner not in owners:
                 owners.append(owner)
 
-    return {"file": str(root / location), "owners": owners}
+    return {"file": str(root / location), "owners": owners, "readable": True}
 
 
 def gh_authenticated(cwd):
@@ -254,7 +264,7 @@ def collect(cwd, handoff_doc, paths=None):
     owners = (
         codeowners_for(facts["repo_root"], paths)
         if facts["repo_root"] and paths
-        else {"file": None, "owners": []}
+        else {"file": None, "owners": [], "readable": True}
     )
 
     result = dict(facts)
@@ -277,8 +287,10 @@ def main(argv=None):
     parser.add_argument("--paths", nargs="*", default=[])
     try:
         args = parser.parse_args(argv)
-    except SystemExit:
-        return USAGE_ERROR
+    except SystemExit as exit_signal:
+        # argparse exits 0 for --help and 2 for a bad argument. Preserve that
+        # distinction: --help is a successful request, not a usage error.
+        return USAGE_ERROR if exit_signal.code else CLEAR
 
     result = collect(args.cwd, args.handoff_doc, args.paths)
     print(json.dumps(result, indent=2, sort_keys=True))

--- a/skills/pickup/scripts/preflight.py
+++ b/skills/pickup/scripts/preflight.py
@@ -196,6 +196,13 @@ def gh_authenticated(cwd):
 
 
 def gh_open_prs(cwd):
+    """Open PRs, or None when the lookup failed.
+
+    The distinction carries weight downstream: a resume that cannot see its own
+    pull request opens a duplicate one, unattended. `gh pr list --json` prints
+    `[]` for a repo with nothing open, so silence means failure rather than
+    emptiness.
+    """
     code, out = run(
         [
             "gh", "pr", "list",
@@ -206,11 +213,12 @@ def gh_open_prs(cwd):
         cwd,
     )
     if code != 0 or not out.strip():
-        return []
+        return None
     try:
-        return json.loads(out)
+        parsed = json.loads(out)
     except ValueError:
-        return []
+        return None
+    return parsed if isinstance(parsed, list) else None
 
 
 def find_run_pr(prs, handoff_doc):
@@ -259,7 +267,15 @@ def collect(cwd, handoff_doc, paths=None):
                       "the run could not open or update a PR.",
         })
 
-    existing_pr = find_run_pr(gh_open_prs(cwd), handoff_doc) if authenticated else None
+    open_prs = gh_open_prs(cwd) if authenticated else None
+    if authenticated and open_prs is None:
+        blockers.append({
+            "code": "pr-lookup-failed",
+            "detail": "`gh` is authenticated but could not list open pull "
+                      "requests, so an existing run PR cannot be ruled out. "
+                      "Proceeding would risk opening a duplicate.",
+        })
+    existing_pr = find_run_pr(open_prs, handoff_doc) if open_prs else None
 
     owners = (
         codeowners_for(facts["repo_root"], paths)

--- a/skills/pickup/scripts/preflight.py
+++ b/skills/pickup/scripts/preflight.py
@@ -34,6 +34,13 @@ Known bounds:
   bodies. Two handoff documents sharing a basename across a repo would collide;
   the lowest-numbered match wins, so the collision resolves to a stable answer
   rather than an arbitrary one.
+* The open-PR listing reads one window of `PR_LIST_LIMIT` entries, newest
+  first. A repo busy enough to fill it reports `pr-lookup-truncated` rather than
+  a possibly incomplete answer, since a resume that cannot see its own pull
+  request opens a duplicate.
+* Only the `gh` calls carry a deadline. `git status` may legitimately run long
+  on a large repo with a cold cache, and timing it out would convert a benign
+  state into a blocker.
 
 Run this OUTSIDE the command sandbox. `gh auth status` exits 1 in the sandbox
 because the credential keyring is unreachable, which reports a working install as
@@ -51,16 +58,35 @@ from pathlib import Path
 
 CLEAR, BLOCKED, USAGE_ERROR = 0, 1, 2
 
+# Conventional shell exit status for a timed-out command, reused here so a
+# caller can tell a hang apart from an ordinary failure.
+TIMEOUT_EXIT = 124
+
+# `gh pr list` pages, and a full page means the window may have cut off the
+# run's own PR. Set high enough that saturation signals a pathological repo
+# rather than an ordinary busy one: a 634-PR repo returns in about 3 seconds.
+PR_LIST_LIMIT = 1000
+
+# Only the network-bound `gh` calls get a deadline. `git status` can legitimately
+# take a long time on a large repo with a cold cache, and timing it out would
+# turn a benign state into a blocker.
+GH_TIMEOUT_SECONDS = 30
+
 CODEOWNERS_LOCATIONS = (".github/CODEOWNERS", "CODEOWNERS", "docs/CODEOWNERS")
 
 
-def run(args, cwd):
+def run(args, cwd, timeout=None):
     """Run a command, returning (returncode, raw stdout). Never raises.
 
     Deliberately unstripped. `git status --porcelain` encodes the status in the
     first two columns, so leading whitespace is data; stripping it here silently
     shifted every reported path by one character. Callers wanting a scalar strip
     at the call site.
+
+    `subprocess.TimeoutExpired` is a `SubprocessError`, not an `OSError`, so it
+    needs naming explicitly; without it a deadline would convert a hang into an
+    uncaught traceback, which is worse for a caller that parses stdout as JSON
+    on both the clear and the blocked exit.
     """
     try:
         completed = subprocess.run(
@@ -68,8 +94,11 @@ def run(args, cwd):
             cwd=str(cwd),
             capture_output=True,
             text=True,
+            timeout=timeout,
         )
-    except (OSError, ValueError):
+    except subprocess.TimeoutExpired:
+        return TIMEOUT_EXIT, ""
+    except (OSError, ValueError, subprocess.SubprocessError):
         return 1, ""
     return completed.returncode, completed.stdout
 
@@ -86,8 +115,14 @@ def _default_branch(cwd):
         )
         if code == 0:
             return candidate
-    _, current = run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd)
-    return current.strip() or None
+    code, current = run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd)
+    current = current.strip()
+    # A detached or unborn HEAD prints the literal "HEAD", which is not a branch
+    # name. Returning it would make `on_default_branch` compare a string to
+    # itself and come out true.
+    if code != 0 or not current or current == "HEAD":
+        return None
+    return current
 
 
 def _dirty_paths(porcelain):
@@ -120,6 +155,8 @@ def git_facts(cwd):
             "on_default_branch": False,
             "tree_clean": False,
             "status_ok": False,
+            "detached_head": False,
+            "unborn_branch": False,
             "dirty_paths": [],
         }
 
@@ -132,13 +169,24 @@ def git_facts(cwd):
     status_ok = status_code == 0
     default = _default_branch(cwd)
     dirty = _dirty_paths(porcelain)
+
+    # Both states print "HEAD" from `rev-parse --abbrev-ref`, so neither is
+    # visible in the branch name alone. `symbolic-ref` fails only when HEAD is
+    # detached; `rev-parse --verify HEAD` fails only before the first commit.
+    symbolic_code, _ = run(["git", "symbolic-ref", "--quiet", "HEAD"], cwd)
+    verify_code, _ = run(["git", "rev-parse", "--verify", "--quiet", "HEAD"], cwd)
+    unborn = verify_code != 0
+    detached = symbolic_code != 0 and not unborn
+
     return {
         "repo_root": root,
         "current_branch": branch or None,
         "default_branch": default,
-        "on_default_branch": bool(branch) and branch == default,
+        "on_default_branch": bool(default) and branch == default,
         "tree_clean": status_ok and not dirty,
         "status_ok": status_ok,
+        "detached_head": detached,
+        "unborn_branch": unborn,
         "dirty_paths": dirty,
     }
 
@@ -163,10 +211,15 @@ def _matches_per_segment(pattern, path):
 def _codeowners_matches(pattern, path):
     if pattern == "*":
         return True
+    # A leading `/` anchors the rule to the repository root. Stripping it before
+    # choosing a branch sends anchored rules down the basename path, which then
+    # claims files anywhere in the tree: `/README.md` would own
+    # `docs/README.md`. Capture the anchor before it is discarded.
+    anchored = pattern.startswith("/")
     cleaned = pattern.lstrip("/")
     if cleaned.endswith("/"):
         return path.startswith(cleaned)
-    if "/" not in cleaned:
+    if "/" not in cleaned and not anchored:
         return fnmatch.fnmatch(os.path.basename(path), cleaned)
     if path.startswith(cleaned + "/"):
         return True
@@ -190,7 +243,11 @@ def codeowners_for(repo_root, paths):
         return {"file": None, "owners": [], "readable": True}
 
     try:
-        contents = (root / location).read_text()
+        # Pin the encoding. Defaulting to the platform's preferred encoding
+        # makes the unreadable branch depend on the host locale: on a latin-1
+        # host a corrupt file decodes to mojibake, no error is raised, and the
+        # result is the silent zero `readable` exists to prevent.
+        contents = (root / location).read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return {"file": str(root / location), "owners": [], "readable": False}
 
@@ -217,9 +274,16 @@ def codeowners_for(repo_root, paths):
     return {"file": str(root / location), "owners": owners, "readable": True}
 
 
-def gh_authenticated(cwd):
-    code, _ = run(["gh", "auth", "status"], cwd)
-    return code == 0
+def gh_auth_state(cwd):
+    """One of "ok", "timeout", or "unauthenticated".
+
+    A hung network call and a missing credential need different remedies, so
+    reporting both as unauthenticated sends the reader after the wrong problem.
+    """
+    code, _ = run(["gh", "auth", "status"], cwd, timeout=GH_TIMEOUT_SECONDS)
+    if code == TIMEOUT_EXIT:
+        return "timeout"
+    return "ok" if code == 0 else "unauthenticated"
 
 
 def gh_open_prs(cwd):
@@ -235,9 +299,10 @@ def gh_open_prs(cwd):
             "gh", "pr", "list",
             "--state", "open",
             "--json", "number,url,headRefName,body",
-            "--limit", "100",
+            "--limit", str(PR_LIST_LIMIT),
         ],
         cwd,
+        timeout=GH_TIMEOUT_SECONDS,
     )
     if code != 0 or not out.strip():
         return None
@@ -283,6 +348,19 @@ def collect(cwd, handoff_doc, paths=None):
             "detail": "`git status` failed, so the tree state is unknown. "
                       "A clean-looking empty result cannot be trusted here.",
         })
+    elif facts["unborn_branch"]:
+        blockers.append({
+            "code": "unborn-branch",
+            "detail": "The repository has no commit yet, so there is no branch "
+                      "to build on.",
+        })
+    elif facts["detached_head"]:
+        blockers.append({
+            "code": "detached-head",
+            "detail": "HEAD is detached. Committing here orphans the work, and "
+                      "the literal branch name \"HEAD\" reads as an ordinary "
+                      "feature branch.",
+        })
     elif not facts["tree_clean"]:
         blockers.append({
             "code": "dirty-tree",
@@ -299,8 +377,17 @@ def collect(cwd, handoff_doc, paths=None):
             "detail": "Cannot read handoff document at {}.".format(handoff_doc),
         })
 
-    authenticated = gh_authenticated(cwd)
-    if not authenticated:
+    auth_state = gh_auth_state(cwd)
+    authenticated = auth_state == "ok"
+    if auth_state == "timeout":
+        blockers.append({
+            "code": "gh-timeout",
+            "detail": "`gh auth status` did not respond within {} seconds; "
+                      "the network or proxy is not answering.".format(
+                          GH_TIMEOUT_SECONDS
+                      ),
+        })
+    elif not authenticated:
         blockers.append({
             "code": "gh-unauthenticated",
             "detail": "`gh` is unavailable or not authenticated; "
@@ -308,6 +395,12 @@ def collect(cwd, handoff_doc, paths=None):
         })
 
     open_prs = gh_open_prs(cwd) if authenticated else None
+    if authenticated and open_prs is not None and len(open_prs) >= PR_LIST_LIMIT:
+        blockers.append({
+            "code": "pr-lookup-truncated",
+            "detail": "The open-PR listing filled its {}-entry window, so an "
+                      "existing run PR cannot be ruled out.".format(PR_LIST_LIMIT),
+        })
     if authenticated and open_prs is None:
         blockers.append({
             "code": "pr-lookup-failed",
@@ -326,7 +419,7 @@ def collect(cwd, handoff_doc, paths=None):
     result = dict(facts)
     result.update({
         "handoff_doc": {"path": str(handoff_doc), "readable": doc_readable},
-        "gh_authenticated": authenticated,
+        "gh_auth_state": auth_state,
         "existing_pr": existing_pr,
         "codeowners": owners,
         "blockers": blockers,

--- a/skills/pickup/scripts/preflight.py
+++ b/skills/pickup/scripts/preflight.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Report the mechanically checkable preconditions for a `/pickup` run.
+
+Usage: preflight.py --handoff-doc <path> [--cwd <dir>] [--paths <path>...]
+
+Prints one JSON object of facts on stdout and exits:
+
+    0  clear    no mechanical blocker; the run may proceed to triage
+    1  blocked  at least one blocker; `blockers` says which
+    2  usage    the arguments were wrong; no facts were gathered
+
+The point of this script is that `/pickup` runs unattended. A gate that depends
+on the model remembering to check is not a gate, so every precondition that can
+be settled by looking rather than by reasoning is settled here, once, and
+reported as a fact.
+
+The converse bound matters just as much: only mechanically determinable blockers
+belong in `blockers`. Whether a handoff document contradicts its linked issue, or
+whether a change is irreversible, is model judgment and lives in TRIAGE.md. This
+script must never look like it has ruled on those.
+
+Known bounds:
+
+* CODEOWNERS support covers `*`, basename globs (`*.md`), directory prefixes
+  (`skills/`), and anchored paths, with last-match-wins. It does not implement
+  negation or the full gitignore pattern grammar. An unmatched path contributes
+  no owners rather than a wrong one.
+* The default branch is read from `origin/HEAD` when a remote is configured, and
+  otherwise inferred from whether `main` or `master` exists locally. A repo whose
+  default branch is neither, and which has no remote, reports its current branch.
+* Resume detection matches the handoff document's basename against open PR
+  bodies. Two handoff documents sharing a basename across a repo would collide;
+  the lowest-numbered match wins, so the collision resolves to a stable answer
+  rather than an arbitrary one.
+
+Run this OUTSIDE the command sandbox. `gh auth status` exits 1 in the sandbox
+because the credential keyring is unreachable, which reports a working install as
+`gh-unauthenticated` and blocks every run. The `gh` calls the rest of the
+pipeline makes have the same constraint, so this is the existing rule for `gh`
+rather than a new one.
+"""
+import argparse
+import fnmatch
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+CLEAR, BLOCKED, USAGE_ERROR = 0, 1, 2
+
+CODEOWNERS_LOCATIONS = (".github/CODEOWNERS", "CODEOWNERS", "docs/CODEOWNERS")
+
+
+def run(args, cwd):
+    """Run a command, returning (returncode, raw stdout). Never raises.
+
+    Deliberately unstripped. `git status --porcelain` encodes the status in the
+    first two columns, so leading whitespace is data; stripping it here silently
+    shifted every reported path by one character. Callers wanting a scalar strip
+    at the call site.
+    """
+    try:
+        completed = subprocess.run(
+            args,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, ValueError):
+        return 1, ""
+    return completed.returncode, completed.stdout
+
+
+def _default_branch(cwd):
+    code, out = run(
+        ["git", "symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"], cwd
+    )
+    if code == 0 and out.strip():
+        return out.strip().rsplit("/", 1)[-1]
+    for candidate in ("main", "master"):
+        code, _ = run(
+            ["git", "show-ref", "--verify", "--quiet", "refs/heads/" + candidate], cwd
+        )
+        if code == 0:
+            return candidate
+    _, current = run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd)
+    return current.strip() or None
+
+
+def _dirty_paths(porcelain):
+    """Paths from `git status --porcelain`, including untracked.
+
+    Untracked files count as dirty. An unattended run must not bulldoze work
+    whose origin it cannot establish, and untracked files are precisely the case
+    where it has the least idea what it would be destroying.
+    """
+    paths = []
+    for line in porcelain.splitlines():
+        if len(line) < 4:
+            continue
+        path = line[3:]
+        # Renames arrive as "old -> new"; the destination is what exists now.
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        paths.append(path.strip('"'))
+    return paths
+
+
+def git_facts(cwd):
+    code, root = run(["git", "rev-parse", "--show-toplevel"], cwd)
+    root = root.strip()
+    if code != 0 or not root:
+        return {
+            "repo_root": None,
+            "current_branch": None,
+            "default_branch": None,
+            "on_default_branch": False,
+            "tree_clean": False,
+            "dirty_paths": [],
+        }
+
+    _, branch = run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd)
+    branch = branch.strip()
+    _, porcelain = run(["git", "status", "--porcelain"], cwd)
+    default = _default_branch(cwd)
+    dirty = _dirty_paths(porcelain)
+    return {
+        "repo_root": root,
+        "current_branch": branch or None,
+        "default_branch": default,
+        "on_default_branch": bool(branch) and branch == default,
+        "tree_clean": not dirty,
+        "dirty_paths": dirty,
+    }
+
+
+def _codeowners_matches(pattern, path):
+    if pattern == "*":
+        return True
+    cleaned = pattern.lstrip("/")
+    if cleaned.endswith("/"):
+        return path.startswith(cleaned)
+    if "/" not in cleaned:
+        return fnmatch.fnmatch(os.path.basename(path), cleaned)
+    return fnmatch.fnmatch(path, cleaned) or path.startswith(cleaned + "/")
+
+
+def codeowners_for(repo_root, paths):
+    """Owners of `paths`, unioned, using last-match-wins per path."""
+    root = Path(repo_root)
+    location = None
+    for candidate in CODEOWNERS_LOCATIONS:
+        if (root / candidate).is_file():
+            location = candidate
+            break
+    if location is None:
+        return {"file": None, "owners": []}
+
+    rules = []
+    for line in (root / location).read_text().splitlines():
+        line = line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        fields = line.split()
+        if len(fields) < 2:
+            continue
+        rules.append((fields[0], fields[1:]))
+
+    owners = []
+    for path in paths or []:
+        winner = None
+        for pattern, pattern_owners in rules:
+            if _codeowners_matches(pattern, path):
+                winner = pattern_owners
+        for owner in winner or []:
+            if owner not in owners:
+                owners.append(owner)
+
+    return {"file": str(root / location), "owners": owners}
+
+
+def gh_authenticated(cwd):
+    code, _ = run(["gh", "auth", "status"], cwd)
+    return code == 0
+
+
+def gh_open_prs(cwd):
+    code, out = run(
+        [
+            "gh", "pr", "list",
+            "--state", "open",
+            "--json", "number,url,headRefName,body",
+            "--limit", "100",
+        ],
+        cwd,
+    )
+    if code != 0 or not out.strip():
+        return []
+    try:
+        return json.loads(out)
+    except ValueError:
+        return []
+
+
+def find_run_pr(prs, handoff_doc):
+    """The open PR belonging to this run, or None.
+
+    Keyed on the handoff document a PR body cites rather than on the branch name,
+    so a run resumes even when the branch was renamed between sessions.
+    """
+    needle = os.path.basename(handoff_doc)
+    matches = [pr for pr in prs if needle in (pr.get("body") or "")]
+    if not matches:
+        return None
+    return sorted(matches, key=lambda pr: pr.get("number", 0))[0]
+
+
+def collect(cwd, handoff_doc, paths=None):
+    facts = git_facts(cwd)
+    blockers = []
+
+    if facts["repo_root"] is None:
+        blockers.append({
+            "code": "not-a-git-repo",
+            "detail": "{} is not inside a git repository.".format(cwd),
+        })
+    elif not facts["tree_clean"]:
+        blockers.append({
+            "code": "dirty-tree",
+            "detail": "Uncommitted or untracked changes: {}.".format(
+                ", ".join(facts["dirty_paths"][:10])
+            ),
+        })
+
+    doc = Path(handoff_doc)
+    doc_readable = doc.is_file() and os.access(str(doc), os.R_OK)
+    if not doc_readable:
+        blockers.append({
+            "code": "handoff-doc-unreadable",
+            "detail": "Cannot read handoff document at {}.".format(handoff_doc),
+        })
+
+    authenticated = gh_authenticated(cwd)
+    if not authenticated:
+        blockers.append({
+            "code": "gh-unauthenticated",
+            "detail": "`gh` is unavailable or not authenticated; "
+                      "the run could not open or update a PR.",
+        })
+
+    existing_pr = find_run_pr(gh_open_prs(cwd), handoff_doc) if authenticated else None
+
+    owners = (
+        codeowners_for(facts["repo_root"], paths)
+        if facts["repo_root"] and paths
+        else {"file": None, "owners": []}
+    )
+
+    result = dict(facts)
+    result.update({
+        "handoff_doc": {"path": str(handoff_doc), "readable": doc_readable},
+        "gh_authenticated": authenticated,
+        "existing_pr": existing_pr,
+        "codeowners": owners,
+        "blockers": blockers,
+    })
+    return result
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Mechanical preconditions for a /pickup run."
+    )
+    parser.add_argument("--handoff-doc", required=True)
+    parser.add_argument("--cwd", default=".")
+    parser.add_argument("--paths", nargs="*", default=[])
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit:
+        return USAGE_ERROR
+
+    result = collect(args.cwd, args.handoff_doc, args.paths)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return BLOCKED if result["blockers"] else CLEAR
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/pickup/scripts/preflight.py
+++ b/skills/pickup/scripts/preflight.py
@@ -265,7 +265,14 @@ def collect(cwd, handoff_doc, paths=None):
     facts = git_facts(cwd)
     blockers = []
 
-    if facts["repo_root"] is None:
+    if not Path(cwd).is_dir():
+        # An unreachable directory fails the same git call as a real directory
+        # outside any repo, so the causes have to be told apart here.
+        blockers.append({
+            "code": "cwd-unreadable",
+            "detail": "{} does not exist or cannot be read.".format(cwd),
+        })
+    elif facts["repo_root"] is None:
         blockers.append({
             "code": "not-a-git-repo",
             "detail": "{} is not inside a git repository.".format(cwd),

--- a/skills/pickup/scripts/test_preflight.py
+++ b/skills/pickup/scripts/test_preflight.py
@@ -9,7 +9,9 @@ the default branch") are exactly the ones a stub would answer by restating the
 test's own assumption. The `gh` half is patched instead: it needs network and an
 authenticated CLI, and CI has neither.
 """
+import contextlib
 import importlib.util
+import io
 import json
 import os
 import subprocess
@@ -183,6 +185,39 @@ class Codeowners(unittest.TestCase):
         (repo / "CODEOWNERS").write_text("docs/ @docs-team\n")
         result = preflight.codeowners_for(repo, ["skills/pickup/SKILL.md"])
         self.assertEqual(result["owners"], [])
+        self.assertTrue(result["readable"])
+
+    def test_undecodable_file_reports_unreadable_rather_than_no_owners(self):
+        """An empty owner list must mean "no rule matched", never "the file
+        could not be read". Collapsing the two is a silent zero: the run would
+        report nobody owns the code when it simply failed to look."""
+        repo = make_repo()
+        (repo / "CODEOWNERS").write_bytes(b"\xff\xfe* @default-owner\n")
+        result = preflight.codeowners_for(repo, ["skills/pickup/SKILL.md"])
+        self.assertFalse(result["readable"])
+        self.assertEqual(result["owners"], [])
+
+    @unittest.skipIf(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        "root reads regardless of mode bits",
+    )
+    def test_unreadable_file_does_not_raise(self):
+        repo = make_repo()
+        owners_file = repo / "CODEOWNERS"
+        owners_file.write_text("* @default-owner\n")
+        owners_file.chmod(0o000)
+        try:
+            result = preflight.codeowners_for(repo, ["skills/pickup/SKILL.md"])
+        finally:
+            owners_file.chmod(0o644)
+        self.assertFalse(result["readable"])
+        self.assertEqual(result["owners"], [])
+
+    def test_absent_file_counts_as_readable(self):
+        """No CODEOWNERS is a known state, not a failure to read one."""
+        repo = make_repo()
+        result = preflight.codeowners_for(repo, ["skills/pickup/SKILL.md"])
+        self.assertTrue(result["readable"])
 
 
 class FindRunPr(unittest.TestCase):
@@ -337,6 +372,14 @@ class Cli(unittest.TestCase):
     def test_missing_required_argument_is_a_usage_error(self):
         code, _ = self.run_main(["--cwd", "/tmp"])
         self.assertEqual(code, preflight.USAGE_ERROR)
+
+    def test_help_exits_zero(self):
+        """`--help` is a successful request for help, not a usage error.
+        argparse already encodes that distinction in the code it raises with;
+        flattening every SystemExit discards it."""
+        with contextlib.redirect_stdout(io.StringIO()):
+            code = preflight.main(["--help"])
+        self.assertEqual(code, preflight.CLEAR)
 
 
 if __name__ == "__main__":

--- a/skills/pickup/scripts/test_preflight.py
+++ b/skills/pickup/scripts/test_preflight.py
@@ -69,6 +69,16 @@ def make_repo(default_branch="main"):
     return path
 
 
+def make_unborn_repo():
+    """An initialised repo with no commit yet, so HEAD points at nothing."""
+    path = Path(tempfile.mkdtemp())
+    git(path, "init", "-q")
+    subprocess.run(
+        ["git", "symbolic-ref", "HEAD", "refs/heads/main"], cwd=path, check=True
+    )
+    return path
+
+
 def make_handoff_doc(name="handoff-thing.md"):
     """A handoff document outside any repository.
 
@@ -151,6 +161,30 @@ class GitFacts(unittest.TestCase):
         facts = preflight.git_facts(repo)
         self.assertTrue(facts["status_ok"])
 
+    def test_detached_head_is_reported(self):
+        """`rev-parse --abbrev-ref HEAD` prints the literal "HEAD" when detached,
+        which reads as an ordinary branch name. Left unflagged, the run commits
+        onto a detached HEAD and the work is orphaned."""
+        repo = make_repo()
+        git(repo, "checkout", "-q", "--detach")
+        facts = preflight.git_facts(repo)
+        self.assertTrue(facts["detached_head"])
+
+    def test_unborn_branch_is_reported(self):
+        """An unborn HEAD also prints "HEAD", and the default-branch fallback
+        then returns that same string, making on_default_branch trivially true."""
+        repo = make_unborn_repo()
+        facts = preflight.git_facts(repo)
+        self.assertTrue(facts["unborn_branch"])
+        self.assertNotEqual(facts["default_branch"], "HEAD")
+        self.assertFalse(facts["on_default_branch"])
+
+    def test_ordinary_repo_is_neither_detached_nor_unborn(self):
+        repo = make_repo()
+        facts = preflight.git_facts(repo)
+        self.assertFalse(facts["detached_head"])
+        self.assertFalse(facts["unborn_branch"])
+
     def test_non_repo_reports_no_root(self):
         outside = Path(tempfile.mkdtemp())
         facts = preflight.git_facts(outside)
@@ -208,6 +242,34 @@ class Codeowners(unittest.TestCase):
         result = preflight.codeowners_for(repo, ["skills/pickup/SKILL.md"])
         self.assertEqual(result["owners"], [])
         self.assertTrue(result["readable"])
+
+    def test_anchored_patterns_match_only_at_the_root(self):
+        """A leading `/` anchors a CODEOWNERS rule to the repository root.
+        Stripping it before deciding which branch to take sends anchored rules
+        down the basename path, which names owners for files they do not own."""
+        repo = make_repo()
+        (repo / "CODEOWNERS").write_text(
+            "/*.md @root-glob\n"
+            "/README.md @root-literal\n"
+        )
+        self.assertEqual(
+            preflight.codeowners_for(repo, ["docs/sub/file.md"])["owners"], []
+        )
+        self.assertEqual(
+            preflight.codeowners_for(repo, ["docs/README.md"])["owners"], []
+        )
+        self.assertEqual(
+            preflight.codeowners_for(repo, ["README.md"])["owners"], ["@root-literal"]
+        )
+        self.assertEqual(
+            preflight.codeowners_for(repo, ["CHANGELOG.md"])["owners"], ["@root-glob"]
+        )
+
+    def test_anchored_directory_still_matches_below_itself(self):
+        repo = make_repo()
+        (repo / "CODEOWNERS").write_text("/docs @docs-team\n")
+        result = preflight.codeowners_for(repo, ["docs/sub/file.md"])
+        self.assertEqual(result["owners"], ["@docs-team"])
 
     def test_star_does_not_cross_a_path_separator(self):
         """Python's fnmatch lets `*` match `/`, so `docs/*.md` would otherwise
@@ -326,9 +388,9 @@ class Blockers(unittest.TestCase):
     contradicting its issue, an irreversible change) stay model judgment in
     TRIAGE.md; this script must never appear to have ruled on them."""
 
-    def collect(self, repo, handoff, prs=None, authed=True):
+    def collect(self, repo, handoff, prs=None, authed="ok"):
         with mock.patch.object(preflight, "gh_open_prs", return_value=prs or []), \
-             mock.patch.object(preflight, "gh_authenticated", return_value=authed):
+             mock.patch.object(preflight, "gh_auth_state", return_value=authed):
             return preflight.collect(repo, handoff)
 
     def test_clean_run_has_no_blockers(self):
@@ -367,7 +429,7 @@ class Blockers(unittest.TestCase):
 
     def test_unauthenticated_gh_blocks(self):
         repo = make_repo()
-        result = self.collect(repo, make_handoff_doc(), authed=False)
+        result = self.collect(repo, make_handoff_doc(), authed="unauthenticated")
         self.assertIn("gh-unauthenticated", [b["code"] for b in result["blockers"]])
 
     def test_default_branch_is_not_a_blocker(self):
@@ -381,7 +443,7 @@ class Blockers(unittest.TestCase):
     def test_every_blocker_carries_a_detail(self):
         repo = make_repo()
         (repo / "stray.txt").write_text("x\n")
-        result = self.collect(repo, str(repo / "nope.md"), authed=False)
+        result = self.collect(repo, str(repo / "nope.md"), authed="unauthenticated")
         self.assertTrue(result["blockers"])
         for blocker in result["blockers"]:
             self.assertTrue(blocker.get("detail"), blocker)
@@ -393,14 +455,14 @@ class Resume(unittest.TestCase):
         doc = make_handoff_doc()
         prs = [{"number": 11, "body": "handoff-thing.md", "url": "u", "headRefName": "feat/thing"}]
         with mock.patch.object(preflight, "gh_open_prs", return_value=prs), \
-             mock.patch.object(preflight, "gh_authenticated", return_value=True):
+             mock.patch.object(preflight, "gh_auth_state", return_value="ok"):
             result = preflight.collect(repo, doc)
         self.assertEqual(result["existing_pr"]["number"], 11)
 
     def test_absent_pr_is_null(self):
         repo = make_repo()
         with mock.patch.object(preflight, "gh_open_prs", return_value=[]), \
-             mock.patch.object(preflight, "gh_authenticated", return_value=True):
+             mock.patch.object(preflight, "gh_auth_state", return_value="ok"):
             result = preflight.collect(repo, make_handoff_doc())
         self.assertIsNone(result["existing_pr"])
 
@@ -415,16 +477,47 @@ class Resume(unittest.TestCase):
 
         with mock.patch.object(preflight, "run", side_effect=fake_run), \
              mock.patch.object(preflight, "gh_open_prs", return_value=[]), \
-             mock.patch.object(preflight, "gh_authenticated", return_value=True):
+             mock.patch.object(preflight, "gh_auth_state", return_value="ok"):
             result = preflight.collect(repo, make_handoff_doc())
         self.assertIn("git-status-failed", [b["code"] for b in result["blockers"]])
+
+    def test_saturated_lookup_blocks(self):
+        """A full page means the window may have cut off the run's own PR.
+        `gh pr list` returns newest first, so a stale resume against a busy repo
+        is the case that silently opens a duplicate."""
+        repo = make_repo()
+        page = [{"number": n, "body": ""} for n in range(preflight.PR_LIST_LIMIT)]
+        with mock.patch.object(preflight, "gh_open_prs", return_value=page), \
+             mock.patch.object(preflight, "gh_auth_state", return_value="ok"):
+            result = preflight.collect(repo, make_handoff_doc())
+        self.assertIn("pr-lookup-truncated", [b["code"] for b in result["blockers"]])
+
+    def test_short_page_does_not_block(self):
+        repo = make_repo()
+        page = [{"number": 1, "body": ""}]
+        with mock.patch.object(preflight, "gh_open_prs", return_value=page), \
+             mock.patch.object(preflight, "gh_auth_state", return_value="ok"):
+            result = preflight.collect(repo, make_handoff_doc())
+        self.assertNotIn(
+            "pr-lookup-truncated", [b["code"] for b in result["blockers"]]
+        )
+
+    def test_gh_timeout_is_not_reported_as_unauthenticated(self):
+        """A hung network call and a missing credential are different problems
+        with different remedies; one label for both sends the reader wrong."""
+        repo = make_repo()
+        with mock.patch.object(preflight, "gh_auth_state", return_value="timeout"):
+            result = preflight.collect(repo, make_handoff_doc())
+        codes = [b["code"] for b in result["blockers"]]
+        self.assertIn("gh-timeout", codes)
+        self.assertNotIn("gh-unauthenticated", codes)
 
     def test_failed_lookup_blocks_rather_than_reporting_no_pr(self):
         """Proceeding on a failed lookup would open a second PR for a run that
         already has one, unattended and outward-facing."""
         repo = make_repo()
         with mock.patch.object(preflight, "gh_open_prs", return_value=None), \
-             mock.patch.object(preflight, "gh_authenticated", return_value=True):
+             mock.patch.object(preflight, "gh_auth_state", return_value="ok"):
             result = preflight.collect(repo, make_handoff_doc())
         self.assertIn("pr-lookup-failed", [b["code"] for b in result["blockers"]])
         self.assertIsNone(result["existing_pr"])
@@ -432,7 +525,7 @@ class Resume(unittest.TestCase):
     def test_genuinely_empty_lookup_does_not_block(self):
         repo = make_repo()
         with mock.patch.object(preflight, "gh_open_prs", return_value=[]), \
-             mock.patch.object(preflight, "gh_authenticated", return_value=True):
+             mock.patch.object(preflight, "gh_auth_state", return_value="ok"):
             result = preflight.collect(repo, make_handoff_doc())
         self.assertNotIn("pr-lookup-failed", [b["code"] for b in result["blockers"]])
 
@@ -440,7 +533,7 @@ class Resume(unittest.TestCase):
         """One root cause, one blocker. The gh-unauthenticated blocker already
         explains why no lookup happened."""
         repo = make_repo()
-        with mock.patch.object(preflight, "gh_authenticated", return_value=False):
+        with mock.patch.object(preflight, "gh_auth_state", return_value="unauthenticated"):
             result = preflight.collect(repo, make_handoff_doc())
         codes = [b["code"] for b in result["blockers"]]
         self.assertIn("gh-unauthenticated", codes)
@@ -451,17 +544,17 @@ class Resume(unittest.TestCase):
         as though the lookup succeeded would let a resume silently restart."""
         repo = make_repo()
         with mock.patch.object(preflight, "gh_open_prs") as lookup, \
-             mock.patch.object(preflight, "gh_authenticated", return_value=False):
+             mock.patch.object(preflight, "gh_auth_state", return_value="unauthenticated"):
             result = preflight.collect(repo, make_handoff_doc())
         lookup.assert_not_called()
         self.assertIsNone(result["existing_pr"])
 
 
 class Cli(unittest.TestCase):
-    def run_main(self, argv, prs=None, authed=True):
+    def run_main(self, argv, prs=None, authed="ok"):
         out = []
         with mock.patch.object(preflight, "gh_open_prs", return_value=prs or []), \
-             mock.patch.object(preflight, "gh_authenticated", return_value=authed), \
+             mock.patch.object(preflight, "gh_auth_state", return_value=authed), \
              mock.patch("builtins.print", side_effect=lambda *a, **k: out.append(a[0] if a else "")):
             code = preflight.main(argv)
         return code, "\n".join(str(line) for line in out)
@@ -487,6 +580,24 @@ class Cli(unittest.TestCase):
         self.assertEqual(code, preflight.BLOCKED)
         parsed = json.loads(output)
         self.assertTrue(parsed["blockers"])
+
+    def test_paths_resolve_owners_end_to_end(self):
+        """The `--paths` route is what Phase 5 uses to name a reviewer, and it
+        is the one place the CODEOWNERS matcher is reached through `collect`."""
+        repo = make_repo()
+        (repo / ".github").mkdir()
+        (repo / ".github" / "CODEOWNERS").write_text("skills/ @skills-team\n")
+        git(repo, "add", ".github/CODEOWNERS")
+        git(repo, "commit", "-q", "-m", "owners")
+        code, output = self.run_main([
+            "--handoff-doc", make_handoff_doc(),
+            "--cwd", str(repo),
+            "--paths", "skills/pickup/SKILL.md",
+        ])
+        self.assertEqual(code, preflight.CLEAR)
+        parsed = json.loads(output)
+        self.assertEqual(parsed["codeowners"]["owners"], ["@skills-team"])
+        self.assertTrue(parsed["codeowners"]["readable"])
 
     def test_missing_required_argument_is_a_usage_error(self):
         code, _ = self.run_main(["--cwd", "/tmp"])

--- a/skills/pickup/scripts/test_preflight.py
+++ b/skills/pickup/scripts/test_preflight.py
@@ -129,6 +129,28 @@ class GitFacts(unittest.TestCase):
         self.assertFalse(facts["tree_clean"])
         self.assertIn("new.txt", facts["dirty_paths"])
 
+    def test_failed_status_reports_unknown_rather_than_clean(self):
+        """A gate that fails open is worse than no gate. When `git status`
+        fails its output is empty, which looks exactly like a clean tree; the
+        run must refuse rather than proceed on an unknown tree state."""
+        repo = make_repo()
+        real_run = preflight.run
+
+        def fake_run(args, cwd):
+            if "status" in args:
+                return 1, ""
+            return real_run(args, cwd)
+
+        with mock.patch.object(preflight, "run", side_effect=fake_run):
+            facts = preflight.git_facts(repo)
+        self.assertFalse(facts["status_ok"])
+        self.assertFalse(facts["tree_clean"])
+
+    def test_successful_status_is_marked_ok(self):
+        repo = make_repo()
+        facts = preflight.git_facts(repo)
+        self.assertTrue(facts["status_ok"])
+
     def test_non_repo_reports_no_root(self):
         outside = Path(tempfile.mkdtemp())
         facts = preflight.git_facts(outside)
@@ -186,6 +208,22 @@ class Codeowners(unittest.TestCase):
         result = preflight.codeowners_for(repo, ["skills/pickup/SKILL.md"])
         self.assertEqual(result["owners"], [])
         self.assertTrue(result["readable"])
+
+    def test_star_does_not_cross_a_path_separator(self):
+        """Python's fnmatch lets `*` match `/`, so `docs/*.md` would otherwise
+        claim ownership of `docs/sub/file.md` and name the wrong reviewer."""
+        repo = make_repo()
+        (repo / "CODEOWNERS").write_text("docs/*.md @docs-team\n")
+        nested = preflight.codeowners_for(repo, ["docs/sub/file.md"])
+        self.assertEqual(nested["owners"], [])
+        direct = preflight.codeowners_for(repo, ["docs/file.md"])
+        self.assertEqual(direct["owners"], ["@docs-team"])
+
+    def test_directory_prefix_still_matches_at_any_depth(self):
+        repo = make_repo()
+        (repo / "CODEOWNERS").write_text("skills/ @skills-team\n")
+        result = preflight.codeowners_for(repo, ["skills/pickup/scripts/preflight.py"])
+        self.assertEqual(result["owners"], ["@skills-team"])
 
     def test_undecodable_file_reports_unreadable_rather_than_no_owners(self):
         """An empty owner list must mean "no rule matched", never "the file
@@ -355,6 +393,21 @@ class Resume(unittest.TestCase):
              mock.patch.object(preflight, "gh_authenticated", return_value=True):
             result = preflight.collect(repo, make_handoff_doc())
         self.assertIsNone(result["existing_pr"])
+
+    def test_failed_git_status_blocks(self):
+        repo = make_repo()
+        real_run = preflight.run
+
+        def fake_run(args, cwd):
+            if "status" in args:
+                return 1, ""
+            return real_run(args, cwd)
+
+        with mock.patch.object(preflight, "run", side_effect=fake_run), \
+             mock.patch.object(preflight, "gh_open_prs", return_value=[]), \
+             mock.patch.object(preflight, "gh_authenticated", return_value=True):
+            result = preflight.collect(repo, make_handoff_doc())
+        self.assertIn("git-status-failed", [b["code"] for b in result["blockers"]])
 
     def test_failed_lookup_blocks_rather_than_reporting_no_pr(self):
         """Proceeding on a failed lookup would open a second PR for a run that

--- a/skills/pickup/scripts/test_preflight.py
+++ b/skills/pickup/scripts/test_preflight.py
@@ -355,6 +355,16 @@ class Blockers(unittest.TestCase):
         result = self.collect(outside, make_handoff_doc())
         self.assertIn("not-a-git-repo", [b["code"] for b in result["blockers"]])
 
+    def test_missing_cwd_reports_its_own_cause(self):
+        """An unreachable directory and a real directory outside any repo fail
+        the same git call. Reporting both as "not a git repository" sends the
+        reader looking for the wrong problem."""
+        missing = Path(tempfile.mkdtemp()) / "gone"
+        result = self.collect(missing, make_handoff_doc())
+        codes = [b["code"] for b in result["blockers"]]
+        self.assertIn("cwd-unreadable", codes)
+        self.assertNotIn("not-a-git-repo", codes)
+
     def test_unauthenticated_gh_blocks(self):
         repo = make_repo()
         result = self.collect(repo, make_handoff_doc(), authed=False)

--- a/skills/pickup/scripts/test_preflight.py
+++ b/skills/pickup/scripts/test_preflight.py
@@ -220,6 +220,35 @@ class Codeowners(unittest.TestCase):
         self.assertTrue(result["readable"])
 
 
+class GhOpenPrs(unittest.TestCase):
+    """`None` means the lookup failed; `[]` means the repo genuinely has no open
+    PRs. Collapsing them is a silent zero with an outward-facing consequence: a
+    resume that cannot see its own PR opens a duplicate one."""
+
+    def test_valid_empty_list_is_empty(self):
+        with mock.patch.object(preflight, "run", return_value=(0, "[]\n")):
+            self.assertEqual(preflight.gh_open_prs("."), [])
+
+    def test_populated_list_is_parsed(self):
+        payload = '[{"number": 3, "body": "x"}]'
+        with mock.patch.object(preflight, "run", return_value=(0, payload)):
+            self.assertEqual(preflight.gh_open_prs(".")[0]["number"], 3)
+
+    def test_command_failure_is_none(self):
+        with mock.patch.object(preflight, "run", return_value=(1, "")):
+            self.assertIsNone(preflight.gh_open_prs("."))
+
+    def test_unparsable_output_is_none(self):
+        with mock.patch.object(preflight, "run", return_value=(0, "not json")):
+            self.assertIsNone(preflight.gh_open_prs("."))
+
+    def test_empty_output_is_none(self):
+        """`gh pr list --json` prints `[]` when there is nothing. Silence means
+        something went wrong, so it is a failure rather than an empty result."""
+        with mock.patch.object(preflight, "run", return_value=(0, "")):
+            self.assertIsNone(preflight.gh_open_prs("."))
+
+
 class FindRunPr(unittest.TestCase):
     """Resume detection. Keyed on the handoff document a PR body cites, not on
     the branch name, so a run resumes even from a differently named branch."""
@@ -326,6 +355,33 @@ class Resume(unittest.TestCase):
              mock.patch.object(preflight, "gh_authenticated", return_value=True):
             result = preflight.collect(repo, make_handoff_doc())
         self.assertIsNone(result["existing_pr"])
+
+    def test_failed_lookup_blocks_rather_than_reporting_no_pr(self):
+        """Proceeding on a failed lookup would open a second PR for a run that
+        already has one, unattended and outward-facing."""
+        repo = make_repo()
+        with mock.patch.object(preflight, "gh_open_prs", return_value=None), \
+             mock.patch.object(preflight, "gh_authenticated", return_value=True):
+            result = preflight.collect(repo, make_handoff_doc())
+        self.assertIn("pr-lookup-failed", [b["code"] for b in result["blockers"]])
+        self.assertIsNone(result["existing_pr"])
+
+    def test_genuinely_empty_lookup_does_not_block(self):
+        repo = make_repo()
+        with mock.patch.object(preflight, "gh_open_prs", return_value=[]), \
+             mock.patch.object(preflight, "gh_authenticated", return_value=True):
+            result = preflight.collect(repo, make_handoff_doc())
+        self.assertNotIn("pr-lookup-failed", [b["code"] for b in result["blockers"]])
+
+    def test_unauthenticated_gh_does_not_also_report_lookup_failure(self):
+        """One root cause, one blocker. The gh-unauthenticated blocker already
+        explains why no lookup happened."""
+        repo = make_repo()
+        with mock.patch.object(preflight, "gh_authenticated", return_value=False):
+            result = preflight.collect(repo, make_handoff_doc())
+        codes = [b["code"] for b in result["blockers"]]
+        self.assertIn("gh-unauthenticated", codes)
+        self.assertNotIn("pr-lookup-failed", codes)
 
     def test_pr_lookup_skipped_when_gh_unauthenticated(self):
         """No auth means no reliable answer about existing PRs. Reporting null

--- a/skills/pickup/scripts/test_preflight.py
+++ b/skills/pickup/scripts/test_preflight.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Tests for preflight.py.
+
+    python3 -m unittest discover -s skills/pickup/scripts -v
+
+Fully offline. Git facts run against real temporary repositories rather than
+stubs, because the questions preflight asks git ("is this tree dirty", "am I on
+the default branch") are exactly the ones a stub would answer by restating the
+test's own assumption. The `gh` half is patched instead: it needs network and an
+authenticated CLI, and CI has neither.
+"""
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPT = Path(__file__).with_name("preflight.py")
+
+
+def load():
+    spec = importlib.util.spec_from_file_location("preflight", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+preflight = load()
+
+GIT_IDENTITY = [
+    "-c", "user.name=Test",
+    "-c", "user.email=test@example.com",
+    "-c", "commit.gpgsign=false",
+]
+
+
+def git(repo, *args):
+    subprocess.run(
+        ["git", *GIT_IDENTITY, *args],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def make_repo(default_branch="main"):
+    """A committed repo on `default_branch`, with no remote.
+
+    `git init -b` would be shorter but only exists from git 2.28; setting HEAD
+    directly keeps the fixture working on whatever git the runner ships.
+    """
+    path = Path(tempfile.mkdtemp())
+    git(path, "init", "-q")
+    subprocess.run(
+        ["git", "symbolic-ref", "HEAD", "refs/heads/" + default_branch],
+        cwd=path,
+        check=True,
+    )
+    (path / "README.md").write_text("seed\n")
+    git(path, "add", "README.md")
+    git(path, "commit", "-q", "-m", "seed")
+    return path
+
+
+def make_handoff_doc(name="handoff-thing.md"):
+    """A handoff document outside any repository.
+
+    `/handoff` writes to the OS temp directory, not the workspace, and the
+    fixture has to match: dropping the document inside the repo under test would
+    make the tree dirty and trip the very blocker these tests exercise.
+    """
+    doc = Path(tempfile.mkdtemp()) / name
+    doc.write_text("# Handoff\n")
+    return str(doc)
+
+
+class GitFacts(unittest.TestCase):
+    def test_clean_repo_on_default_branch(self):
+        repo = make_repo()
+        facts = preflight.git_facts(repo)
+        self.assertEqual(Path(facts["repo_root"]).resolve(), repo.resolve())
+        self.assertEqual(facts["current_branch"], "main")
+        self.assertTrue(facts["tree_clean"])
+        self.assertEqual(facts["dirty_paths"], [])
+        self.assertTrue(facts["on_default_branch"])
+
+    def test_feature_branch_is_not_default(self):
+        repo = make_repo()
+        git(repo, "checkout", "-q", "-b", "feat/thing")
+        facts = preflight.git_facts(repo)
+        self.assertEqual(facts["current_branch"], "feat/thing")
+        self.assertFalse(facts["on_default_branch"])
+
+    def test_master_repo_detected_as_default(self):
+        repo = make_repo(default_branch="master")
+        facts = preflight.git_facts(repo)
+        self.assertEqual(facts["default_branch"], "master")
+        self.assertTrue(facts["on_default_branch"])
+
+    def test_modified_file_is_dirty(self):
+        repo = make_repo()
+        (repo / "README.md").write_text("changed\n")
+        facts = preflight.git_facts(repo)
+        self.assertFalse(facts["tree_clean"])
+        self.assertIn("README.md", facts["dirty_paths"])
+
+    def test_untracked_file_is_dirty(self):
+        """Untracked counts. An unattended run must not bulldoze work whose
+        origin it cannot establish, and untracked files are the case where it
+        has the least idea what it would be destroying."""
+        repo = make_repo()
+        (repo / "stray.txt").write_text("who put this here\n")
+        facts = preflight.git_facts(repo)
+        self.assertFalse(facts["tree_clean"])
+        self.assertIn("stray.txt", facts["dirty_paths"])
+
+    def test_staged_file_is_dirty(self):
+        repo = make_repo()
+        (repo / "new.txt").write_text("staged\n")
+        git(repo, "add", "new.txt")
+        facts = preflight.git_facts(repo)
+        self.assertFalse(facts["tree_clean"])
+        self.assertIn("new.txt", facts["dirty_paths"])
+
+    def test_non_repo_reports_no_root(self):
+        outside = Path(tempfile.mkdtemp())
+        facts = preflight.git_facts(outside)
+        self.assertIsNone(facts["repo_root"])
+
+
+class Codeowners(unittest.TestCase):
+    def test_absent_file_yields_no_owners(self):
+        repo = make_repo()
+        result = preflight.codeowners_for(repo, ["skills/pickup/SKILL.md"])
+        self.assertIsNone(result["file"])
+        self.assertEqual(result["owners"], [])
+
+    def test_glob_rule_matches(self):
+        repo = make_repo()
+        (repo / ".github").mkdir()
+        (repo / ".github" / "CODEOWNERS").write_text("* @default-owner\n")
+        result = preflight.codeowners_for(repo, ["skills/pickup/SKILL.md"])
+        self.assertEqual(result["owners"], ["@default-owner"])
+        self.assertTrue(result["file"].endswith(".github/CODEOWNERS"))
+
+    def test_last_matching_rule_wins(self):
+        repo = make_repo()
+        (repo / "CODEOWNERS").write_text(
+            "* @default-owner\n"
+            "skills/ @skills-team\n"
+        )
+        result = preflight.codeowners_for(repo, ["skills/pickup/SKILL.md"])
+        self.assertEqual(result["owners"], ["@skills-team"])
+
+    def test_comments_and_blank_lines_ignored(self):
+        repo = make_repo()
+        (repo / "CODEOWNERS").write_text(
+            "# ownership\n"
+            "\n"
+            "*.md @docs-team\n"
+        )
+        result = preflight.codeowners_for(repo, ["README.md"])
+        self.assertEqual(result["owners"], ["@docs-team"])
+
+    def test_owners_from_several_paths_are_unioned(self):
+        repo = make_repo()
+        (repo / "CODEOWNERS").write_text(
+            "skills/ @skills-team\n"
+            "*.yml @ci-team\n"
+        )
+        result = preflight.codeowners_for(
+            repo, ["skills/pickup/SKILL.md", ".github/workflows/tests.yml"]
+        )
+        self.assertEqual(sorted(result["owners"]), ["@ci-team", "@skills-team"])
+
+    def test_unmatched_path_contributes_nothing(self):
+        repo = make_repo()
+        (repo / "CODEOWNERS").write_text("docs/ @docs-team\n")
+        result = preflight.codeowners_for(repo, ["skills/pickup/SKILL.md"])
+        self.assertEqual(result["owners"], [])
+
+
+class FindRunPr(unittest.TestCase):
+    """Resume detection. Keyed on the handoff document a PR body cites, not on
+    the branch name, so a run resumes even from a differently named branch."""
+
+    HANDOFF = "/tmp/scratch/handoff-featurecard-layout.md"
+
+    def test_no_open_prs(self):
+        self.assertIsNone(preflight.find_run_pr([], self.HANDOFF))
+
+    def test_body_citing_the_handoff_matches(self):
+        prs = [{"number": 7, "body": "Picked up from handoff-featurecard-layout.md"}]
+        self.assertEqual(preflight.find_run_pr(prs, self.HANDOFF)["number"], 7)
+
+    def test_unrelated_prs_do_not_match(self):
+        prs = [
+            {"number": 4, "body": "unrelated work"},
+            {"number": 5, "body": "handoff-other-thing.md"},
+        ]
+        self.assertIsNone(preflight.find_run_pr(prs, self.HANDOFF))
+
+    def test_lowest_number_wins_when_several_match(self):
+        """Two PRs citing one handoff means an earlier run was abandoned rather
+        than resumed. The older one is the run to rejoin."""
+        prs = [
+            {"number": 9, "body": "handoff-featurecard-layout.md"},
+            {"number": 3, "body": "handoff-featurecard-layout.md"},
+        ]
+        self.assertEqual(preflight.find_run_pr(prs, self.HANDOFF)["number"], 3)
+
+    def test_missing_body_is_tolerated(self):
+        prs = [{"number": 2}, {"number": 3, "body": None}]
+        self.assertIsNone(preflight.find_run_pr(prs, self.HANDOFF))
+
+
+class Blockers(unittest.TestCase):
+    """Only mechanically determinable blockers belong here. Semantic ones (a doc
+    contradicting its issue, an irreversible change) stay model judgment in
+    TRIAGE.md; this script must never appear to have ruled on them."""
+
+    def collect(self, repo, handoff, prs=None, authed=True):
+        with mock.patch.object(preflight, "gh_open_prs", return_value=prs or []), \
+             mock.patch.object(preflight, "gh_authenticated", return_value=authed):
+            return preflight.collect(repo, handoff)
+
+    def test_clean_run_has_no_blockers(self):
+        repo = make_repo()
+        git(repo, "checkout", "-q", "-b", "feat/thing")
+        result = self.collect(repo, make_handoff_doc())
+        self.assertEqual(result["blockers"], [])
+
+    def test_dirty_tree_blocks(self):
+        repo = make_repo()
+        (repo / "stray.txt").write_text("x\n")
+        result = self.collect(repo, make_handoff_doc())
+        self.assertIn("dirty-tree", [b["code"] for b in result["blockers"]])
+
+    def test_missing_handoff_doc_blocks(self):
+        repo = make_repo()
+        result = self.collect(repo, str(repo / "nope.md"))
+        self.assertIn(
+            "handoff-doc-unreadable", [b["code"] for b in result["blockers"]]
+        )
+
+    def test_non_repo_blocks(self):
+        outside = Path(tempfile.mkdtemp())
+        result = self.collect(outside, make_handoff_doc())
+        self.assertIn("not-a-git-repo", [b["code"] for b in result["blockers"]])
+
+    def test_unauthenticated_gh_blocks(self):
+        repo = make_repo()
+        result = self.collect(repo, make_handoff_doc(), authed=False)
+        self.assertIn("gh-unauthenticated", [b["code"] for b in result["blockers"]])
+
+    def test_default_branch_is_not_a_blocker(self):
+        """Sitting on main is the expected starting state; the skill branches
+        from it. Blocking here would reject the common case."""
+        repo = make_repo()
+        result = self.collect(repo, make_handoff_doc())
+        self.assertNotIn("on-default-branch", [b["code"] for b in result["blockers"]])
+        self.assertTrue(result["on_default_branch"])
+
+    def test_every_blocker_carries_a_detail(self):
+        repo = make_repo()
+        (repo / "stray.txt").write_text("x\n")
+        result = self.collect(repo, str(repo / "nope.md"), authed=False)
+        self.assertTrue(result["blockers"])
+        for blocker in result["blockers"]:
+            self.assertTrue(blocker.get("detail"), blocker)
+
+
+class Resume(unittest.TestCase):
+    def test_existing_pr_is_surfaced(self):
+        repo = make_repo()
+        doc = make_handoff_doc()
+        prs = [{"number": 11, "body": "handoff-thing.md", "url": "u", "headRefName": "feat/thing"}]
+        with mock.patch.object(preflight, "gh_open_prs", return_value=prs), \
+             mock.patch.object(preflight, "gh_authenticated", return_value=True):
+            result = preflight.collect(repo, doc)
+        self.assertEqual(result["existing_pr"]["number"], 11)
+
+    def test_absent_pr_is_null(self):
+        repo = make_repo()
+        with mock.patch.object(preflight, "gh_open_prs", return_value=[]), \
+             mock.patch.object(preflight, "gh_authenticated", return_value=True):
+            result = preflight.collect(repo, make_handoff_doc())
+        self.assertIsNone(result["existing_pr"])
+
+    def test_pr_lookup_skipped_when_gh_unauthenticated(self):
+        """No auth means no reliable answer about existing PRs. Reporting null
+        as though the lookup succeeded would let a resume silently restart."""
+        repo = make_repo()
+        with mock.patch.object(preflight, "gh_open_prs") as lookup, \
+             mock.patch.object(preflight, "gh_authenticated", return_value=False):
+            result = preflight.collect(repo, make_handoff_doc())
+        lookup.assert_not_called()
+        self.assertIsNone(result["existing_pr"])
+
+
+class Cli(unittest.TestCase):
+    def run_main(self, argv, prs=None, authed=True):
+        out = []
+        with mock.patch.object(preflight, "gh_open_prs", return_value=prs or []), \
+             mock.patch.object(preflight, "gh_authenticated", return_value=authed), \
+             mock.patch("builtins.print", side_effect=lambda *a, **k: out.append(a[0] if a else "")):
+            code = preflight.main(argv)
+        return code, "\n".join(str(line) for line in out)
+
+    def test_clean_run_exits_zero_with_json(self):
+        repo = make_repo()
+        git(repo, "checkout", "-q", "-b", "feat/thing")
+        code, output = self.run_main(
+            ["--handoff-doc", make_handoff_doc(), "--cwd", str(repo)]
+        )
+        self.assertEqual(code, preflight.CLEAR)
+        parsed = json.loads(output)
+        self.assertEqual(parsed["current_branch"], "feat/thing")
+
+    def test_blocked_run_exits_one_and_still_emits_json(self):
+        """The blocked exit still prints the full fact set. A gate that reports
+        only its verdict forces the caller to re-derive why."""
+        repo = make_repo()
+        (repo / "stray.txt").write_text("x\n")
+        code, output = self.run_main(
+            ["--handoff-doc", make_handoff_doc(), "--cwd", str(repo)]
+        )
+        self.assertEqual(code, preflight.BLOCKED)
+        parsed = json.loads(output)
+        self.assertTrue(parsed["blockers"])
+
+    def test_missing_required_argument_is_a_usage_error(self):
+        code, _ = self.run_main(["--cwd", "/tmp"])
+        self.assertEqual(code, preflight.USAGE_ERROR)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `/pickup`, the other end of `/handoff`: it takes a handoff document and drives it to a reviewed pull request. This replaces a prompt that was being retyped by hand each time a fresh session opened against a handoff doc.

PR 1 of 2. This ships the skill working against freeform prose handoff documents. PR 2 adds a structured block to `/handoff` and teaches `/pickup` to read it when present, which is an accuracy upgrade rather than a dependency.

> [!IMPORTANT]
> **Every serious defect in this PR was the same bug wearing a different hat: a failure that renders as a benign empty result.** Nine of them. If a defect remains, this is its shape. Review for it directly, using the checklist below, rather than reading the diff top to bottom.

## The one pattern worth your attention

Nine defects, one shape. In each case a call failed, produced nothing, and *nothing* was indistinguishable from *fine*:

| What failed | What it returned | What that meant to the caller |
| --- | --- | --- |
| `git status --porcelain` | empty output | **tree is clean** (the hard blocker failed open) |
| `gh pr list` | `[]` | **no open PRs** (a resume would open a duplicate) |
| `read_text()` on CODEOWNERS | `[]` owners | **nobody owns this code** |
| `gh pr list --limit 100` | a full page | **that is all of them** |
| `rev-parse --abbrev-ref HEAD` | `"HEAD"` | **a branch named HEAD** (detached and unborn both) |
| `subprocess` on a bad `cwd` | non-zero | **gh is unauthenticated** |
| `run()` stripping stdout | shifted columns | **every dirty path missing a character** |

None of these were caught by 31 passing tests or by a manual smoke run, because tests and smoke runs exercise the path where things work.

### The check to apply while reviewing

For every branch in `preflight.py` that returns a value, ask two questions:

1. **Can a failure produce this same value?** An empty list, an empty string, a `False`, a zero, a `None`.
2. **If so, can the caller tell the two apart?** If not, that is the bug, whatever the surrounding code looks like.

The fixes in this PR all take the same form: **make the failure representable.** `status_ok` separates "clean" from "could not look". `gh_open_prs` returns `None` for failure and `[]` for genuinely empty. `codeowners.readable` separates "no rule matched" from "could not read". `gh_auth_state` returns one of three strings rather than a boolean. Where a gate cannot know, it now **fails closed** and says which question it could not answer.

Concentrate on: `collect()`'s blocker chain, every `except` clause in `preflight.py`, and any place a `gh` or `git` return code is discarded with `_`.

## Final tally

| | |
| --- | --- |
| Commits | 13 |
| Tests | 31 at first push, 58 now |
| `/pr-review-bot-loop` | 7 rounds, 9 findings, 9 accepted, 0 declined |
| `/pr-review-adversarial` | 29 candidates in, 20 findings out, 0 unadjudicated |
| Defects found and fixed | 19 |
| Deferred | 10 nits (#93) |

## Design

Three modes, second argument, defaulting to `afk`:

| Mode | At triage | At phase boundaries |
| --- | --- | --- |
| `afk` | Proceeds | Proceeds |
| `semi` | Stops for review | Stops with a batch of accumulated questions |
| `hitl` | Stops; `/grill-me` until resolved, `/prototype` when a fork needs seeing | Proceeds |

Strictness for the mode gate runs `afk` < `semi` < `hitl`, ordered by how much the human sees before implementation starts.

Every run begins with a Phase 0 triage that fixes a verification method to each acceptance criterion and classifies every open question, before implementation makes any of it look harder than it did at the start.

Two stop classes, with deliberately asymmetric escape hatches:

- A **hard blocker** (unreadable input, doc/issue contradiction, irreversible or outward-facing change, unverifiable criterion, missing access, dirty tree, detached or unborn HEAD) means the run cannot know something. Nothing bypasses it.
- A **mode mismatch** (3 or more user-visible judgment calls, or 2 clustered on one surface) means the human probably wants to be present. `--force` overrules it.

Judgment calls get built the reversible way, recorded in a Decisions Log, and flagged inline on the diff with `:notebook:` so the fork is reviewed against real code rather than in the abstract.

The pipeline delegates rather than reimplements: `/pr-review-bot-loop` and `/pr-review-adversarial` are part of the validation gate rather than a phase after it. Because adversarial fixes invalidate a clean bot pass, that gate is cyclic and capped at 3 cycles, after which the run stops and reports honestly instead of grinding or declaring victory.

## Reading order

1. `skills/pickup/SKILL.md` - the phase controller. Steps only; start here for the shape.
2. `skills/pickup/TRIAGE.md` - the reference half: classification taxonomies, mode thresholds, artifact formats. Split out because reference interleaved with steps buries the steps.
3. `skills/pickup/scripts/preflight.py` - the mechanical preconditions.
4. `skills/pickup/scripts/test_preflight.py` - 58 offline tests.
5. `.github/workflows/tests.yml` and `README.md` - wiring. Skim.

## What I would tell a reviewer

Three things this PR's green checks do not cover. They are the reasons to read it rather than trust it.

**The last ten fixes carry less scrutiny than everything before them.** The adversarial pass was pinned at `5b3d07c`. The ten fixes it produced sit at a newer SHA and have not themselves been through a pass, and three of them rewrote gate logic. A bot round has run against the current head and surfaced nothing new, which is real but weak evidence: it means one automated reviewer raised no objection at one head, not that the diff is good.

**The prose half is untested by construction.** `SKILL.md` and `TRIAGE.md` are procedure a later session executes literally, and nothing in CI touches them. CI green means `preflight.py` is sound. It says nothing about whether the orchestration works. Six code defects survived 31 passing tests and a manual smoke run before the bot loop found them, so moving a check into a script makes it reliable, not correct.

**Reviewer attention is best spent on the gate's failure modes, not its happy path.** See the checklist at the top; it is the highest-value thing to do with this diff.

## Notes for review

**Why a script at all.** Every precondition that can be settled by looking rather than by reasoning is settled in `preflight.py`. A gate that depends on the model remembering to check is not a gate. The converse bound is enforced too: only mechanically determinable blockers appear in its output, so it never looks like it has ruled on the semantic ones, which stay in `TRIAGE.md` as judgment.

**`preflight.py` must run outside the command sandbox**, using its installed path under `~/.claude/skills/`. `gh auth status` exits 1 in the sandbox because the credential keyring is unreachable, which would report a working install as unauthenticated and block every run.

**Authorization carve-out.** Invoking in `afk` or `semi` authorizes the run to commit, push, publish review replies, and request a reviewer without asking again, scoped to the one PR it created. That is a deliberate departure from the standing convention of staging review comments for manual submission, and it is stated in `SKILL.md` rather than left implicit. Merging, force-pushing, changing repository visibility, and touching any other PR stay out of scope in every mode.

**The thresholds are guesses.** 3 forks, 2 clustered, 3 cycles. Written as visible numbers rather than as vibes, precisely so the first real runs can correct them.

## Review history

### `/pr-review-bot-loop`, 7 rounds

9 findings, 9 accepted, 0 declined (6 code, 3 procedure), terminating clean at round 6. Round 7, run after the adversarial fixes, surfaced one suppressed finding that was already adjudicated and deferred to #93, which is the closest thing here to evidence the fixes introduced no regression.

**8 of the 9 arrived in Copilot's suppressed block**, where every other signal reports clean, so a loop built on the four-signal contract would have terminated after round 1 and shipped the rest.

| Round | Defect | Why it mattered |
| --- | --- | --- |
| 3 | `git_facts()` discarded the return code from `git status --porcelain` | A failed status prints nothing, which read as a clean tree, so the dirty-tree hard blocker **failed open** |
| 5 | `SKILL.md` invoked `preflight.py` by a repo-relative path | Runs happen in the target project, so Phase 0 step 1 would have failed on essentially every real invocation |
| 2 | `gh_open_prs()` collapsed any failure into `[]` | "Lookup failed" was indistinguishable from "no open PRs", so a resume would have opened a **duplicate PR** unattended |

### `/pr-review-adversarial`, pinned at `5b3d07c`

29 candidates in, 20 findings out: 19 `SURVIVES`, 1 `UNDERSTATED`, 5 `REFUTED`, 4 dismissals upheld, 0 unadjudicated. Ten should-fix items fixed here; ten nits deferred to #93 with their adjudicated context.

The pass paid for itself mainly by **breaking proposed fixes rather than claims**. Three that would otherwise have shipped:

- The listing-window fix as first written would have **permanently blocked every run against a repo with a full window**, converting a rare miss into a fail-closed. Corrected to a wider window with saturation detection, after a refuter verified `gh pr list` returns newest-first and so the real risk is a stale resume, not repo size.
- Branching from `origin/<default_branch>` still fails on a repo with no remote, since two of the three resolution paths return a local name. Now falls back to the local branch.
- A blanket subprocess timeout would have landed on `git status`, turning a slow cold-cache repo into a blocker. Scoped to the `gh` calls only.

Five candidates were refuted outright, three of them findings asserted in the first pass, including one "tautological test assertion" disproved by a refuter building the mutant and showing the test fails exactly as designed.

## Validation

- 58 preflight tests pass; the `pr-review-bot-loop` suite still passes (44, 4 skipped)
- `actionlint` clean; markdown table pipe spacing (MD060) clean
- Local Python 3.9.6, matching the CI floor; CI runs 3.9 and 3.13
- CI trigger extended to `skills/pickup/scripts/**` explicitly rather than broadening to `skills/*/scripts/**`, which would hand a future untested script a green run that reads as coverage. Verified in the CI log that the new suite actually executes rather than the sibling's carrying the run
- Every fix carries a regression test confirmed red before the fix

## Where to go next once this ships

In order.

1. **Symlink the skill.** `ln -s ~/dev/claude-workflows/skills/pickup ~/.claude/skills/pickup`. Deferred until merge because the target does not exist before then, and `/pickup` is not invocable without it.
2. **Do one real run, in `hitl`, against a small handoff document.** This is the actual acceptance evidence for the orchestration, which no test in this PR covers. Expect the thresholds to be wrong; they are written as visible numbers so the first runs can correct them.
3. **PR 2: the `/handoff` structured block.** `/handoff` gains an optional section carrying acceptance criteria with verification methods, pre-classified open questions, and linked issues; `/pickup` reads it when present and falls back to prose parsing when absent. Worth landing before trusting `afk` on anything consequential, because prose-parsed triage is the load-bearing unknown in this design: the session that writes the handoff is the only one that ever knew why a question was left open, and by the time a fresh session reads prose, that is gone.
4. **#93**, the ten deferred nits, each with its adjudicated context and revised fix. Two open questions there are worth answering first, since they change what the fixes should be: whether `/pickup` is meant to run against repos with large open-PR counts, and whether a `/pickup` PR body is ever authored by anything other than `/pickup`.
5. **#92**, a gap in `/pr-review-adversarial` rather than in this skill: no guidance for a dispatched subagent that fails rather than returns. Hit three times while reviewing this PR.
