### PR TITLE
feat(hooks): prune mattpocock-skills plugin duplicates on SessionStart

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Hook scripts in `config/hooks/` are symlinked into `~/.claude/hooks/`. Unlike sk
 
 - [`block-em-dash.sh`](config/hooks/block-em-dash.sh) - PreToolUse hook enforcing the no-em-dash rule. Requires matcher `Write|Edit|Bash` in `settings.json` so it inspects the inline Bash command string (`gh`/`git` titles, commit subjects), not just `Write`/`Edit`. Tested via [`block-em-dash.test.sh`](config/hooks/block-em-dash.test.sh) (`bash config/hooks/block-em-dash.test.sh`).
 - [`block-claude-attribution.sh`](config/hooks/block-claude-attribution.sh) - PreToolUse hook blocking Claude attribution footers and `Co-Authored-By` trailers.
+- [`prune-mattpocock-duplicates.sh`](config/hooks/prune-mattpocock-duplicates.sh) - SessionStart hook (no matcher). Deletes the 6 auto-firing `mattpocock-skills` plugin skills that duplicate my customized personal skills, so Claude only sees mine. Runs every session, so it self-heals after a plugin update re-materializes the bundle. Installed for the plugin's `teach` skill; `skillOverrides` cannot target plugin skills, hence the prune approach.
 
 Because the matcher wiring lives in untracked `settings.json`, a committed hook will not fire for anyone who has not mirrored the matcher locally. Tracking that drift is [#24](https://github.com/dgowrie/claude-workflows/issues/24).
 

--- a/config/hooks/prune-mattpocock-duplicates.sh
+++ b/config/hooks/prune-mattpocock-duplicates.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Prune Matt Pocock plugin skills that duplicate my own customized personal
+# skills, so Claude only ever sees my versions.
+#
+# Why this exists:
+#   The mattpocock-skills Claude Code plugin ships ~25 skills as one bundle
+#   (installed for the `teach` skill, kept current via the plugin's auto-update).
+#   Several bundle skills share a name with my personal ~/.claude/skills copies.
+#   Slash invocation already favors mine (the plugin's are namespaced
+#   /mattpocock-skills:<name>), but for the ones that auto-fire, the plugin's
+#   description also loads and competes with mine on model-invocation.
+#
+#   skillOverrides cannot silence a plugin skill (verified: a namespaced key is
+#   ignored, a bare key disables MY copy instead). Deleting the plugin's skill
+#   folder from the cache does work and survives a session, but a plugin update
+#   re-checkouts a fresh copy into a new version directory, bringing the
+#   duplicates back. This SessionStart hook re-prunes them every session, so the
+#   removal is durable and self-healing after updates.
+#
+# Scope: only the duplicates that auto-fire (and thus actually compete). The
+# other name collisions in the bundle are disable-model-invocation, so they
+# never auto-fire and cost nothing; they are left in place.
+#
+# Source of truth: claude-workflows/config/hooks/. Reached via a symlink in
+# ~/.claude/hooks/. If Matt renames or moves one of these skills upstream, its
+# plugin copy will reappear (name no longer matches); update the list below.
+
+set -uo pipefail
+
+plugin_root="${HOME}/.claude/plugins/cache/claude-plugins-official/mattpocock-skills"
+[ -d "$plugin_root" ] || exit 0
+
+# Personal skills the plugin also ships that auto-fire (no disable-model-invocation).
+duplicates=(
+  codebase-design
+  domain-modeling
+  grilling
+  prototype
+  tdd
+  writing-for-agents
+)
+
+for name in "${duplicates[@]}"; do
+  while IFS= read -r skill_md; do
+    rm -rf "$(dirname "$skill_md")"
+  done < <(find "$plugin_root" -type f -path "*/skills/*/${name}/SKILL.md" 2>/dev/null)
+done
+
+exit 0


### PR DESCRIPTION
## Goal

Make Matt Pocock's `teach` skill invokable from anywhere I use Claude, kept current with upstream, without adding it to this repo.

## Decision

Install the official `mattpocock-skills` Claude Code plugin (user scope, auto-updating) rather than vendoring `teach`. The plugin ships ~25 skills as one managed bundle; `teach` is only distributed as part of it. 9 of those collide by name with my customized personal skills in `~/.claude/skills`.

I verified that `skillOverrides` cannot silence a plugin skill: a namespaced key (`mattpocock-skills:tdd`) is silently ignored, and a bare key (`tdd`) disables my own copy instead. Oracle: the deterministic `skills[]` array from `claude -p "hi" --output-format stream-json --verbose`, validated against skills already set to `off`. Full findings in #99 (closed).

Deleting a plugin skill's folder from the cache does remove it from the registry cleanly and survives a session, but not a plugin update (the cache is version-pinned and re-checkouts a fresh copy). So the durable mechanism is a SessionStart hook that re-prunes each session.

## Result / shipped behavior

`config/hooks/prune-mattpocock-duplicates.sh`, a SessionStart hook (no matcher), deletes the 6 auto-firing duplicates from the plugin cache every session:

`codebase-design`, `domain-modeling`, `grilling`, `prototype`, `tdd`, `writing-for-agents`.

- My versions are the only copies Claude sees, on both slash and auto-fire invocation.
- Self-heals after a plugin update re-materializes the bundle.
- The 3 other name collisions (`grill-me`, `handoff`, `improve-codebase-architecture`) are `disable-model-invocation` in the plugin, so they never auto-fire and are left in place.
- `teach` and the other non-colliding bundle skills remain available as `/mattpocock-skills:*`.

Verified end state (deterministic `skills[]` registry): all 6 plugin copies absent, my 6 present, `teach` present, plugin skill count 25 -> 19.

This PR contains the hook script and its README Hooks entry. The plugin install and the SessionStart wiring live in the machine-local, untracked `settings.json` (matching the existing hooks' pattern), so they are not part of the diff.

## Caveat

The prune list matches by skill name. If Matt renames or moves one of the 6 skills upstream, that copy will slip past the list and reappear; fixing it is a one-line update to the array (noted in the script header and in memory). This is inferred from the plugin's version-pinned git-checkout cache structure; I could not test a real version bump because 1.2.3 is current.
