### PR TITLE
docs(rules): add worktree-gotchas global rule

### DIFF
--- a/config/rules/worktree-gotchas.md
+++ b/config/rules/worktree-gotchas.md
@@ -1,0 +1,18 @@
+# Git Worktree Gotchas (Claude Code sessions)
+
+Behaviors seen in sessions rooted in a git worktree (`.claude/worktrees/<name>/`). These look like stale caches, git errors, or flaky tools but are worktree isolation.
+
+## File tools need the full worktree-prefixed absolute path
+
+Read/Write/Edit resolve absolute paths literally. A main-checkout path like `/…/<repo>/src/foo.ts` silently reads/writes the MAIN checkout, not the worktree, even though Bash (running in the worktree cwd) sees the correct files.
+
+- Symptom: Read shows old/main content while `grep`/`nl` via Bash show branch content; or a Write "succeeds" but never appears in the worktree.
+- Apply: always prefix with the worktree root, e.g. `/…/<repo>/.claude/worktrees/<name>/src/foo.ts`. A stray write to the main checkout also trips the sandbox (`Operation not permitted`) and needs `dangerouslyDisableSandbox`.
+
+## The session is hard-isolated to its worktree
+
+- Cannot fast-forward local `main` (it's checked out in the shared checkout): `git fetch . origin/main:main` fails ("refusing to fetch into branch 'main' checked out at ..."), `git -C <main-checkout> ...` is refused by the harness ("must target its own worktree"), and even a user `!`-prefixed command is blocked. Do the `main` fast-forward from a shell OUTSIDE the worktree.
+- `git -C <other-path>` is always refused, regardless of target.
+- Compound Bash commands are refused when the harness can't prove they stay in-worktree ("too complex to verify") - e.g. `cp …; …; >$TMPDIR/x.log` or `for i in $(seq …)` loops with redirects. Split into plain single-purpose commands, and prefer writing logs under the scratchpad absolute path over `$TMPDIR` redirects.
+
+Why: these look like git errors or flaky tool failures but are the worktree-isolation guard.


### PR DESCRIPTION
Promotes two external project memories describing **universal Claude Code worktree behavior** (not repo-specific) into a global rule at `config/rules/worktree-gotchas.md`.

## What it captures
- **File-tool path discipline in worktrees:** Read/Write/Edit resolve literal absolute paths, so a main-checkout path silently hits the main checkout, not the worktree. Always prefix with the worktree root.
- **Worktree isolation guard:** worktree sessions cannot fast-forward local `main`, `git -C` is refused, and compound Bash gets rejected as unverifiable. Do `main` ff from an outside shell; keep Bash single-purpose.

## Why global
These behaviors recur across every worktree session in related external projects, but were siloed in one project's memory. Verified not already present in global CLAUDE.md or any existing rule file.

## Follow-up after merge
Symlink it live like the other rules: `ln -s ~/dev/claude-workflows/config/rules/worktree-gotchas.md ~/.claude/rules/worktree-gotchas.md` (bootstrap step). The two source memories in the external project's sope are being retired as part of this promotion.